### PR TITLE
fix one error in compute_forces_acoustic.f90

### DIFF
--- a/src/specfem2D/specfem2D.F90
+++ b/src/specfem2D/specfem2D.F90
@@ -1042,7 +1042,7 @@
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
                           rmemory_acoustic_dux_dx,rmemory_acoustic_dux_dz
 
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: rmemory_potential_acoust_LDDRK
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: rmemory_potential_acoustic_LDDRK
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
                           rmemory_acoustic_dux_dx_LDDRK,rmemory_acoustic_dux_dz_LDDRK
 
@@ -3155,19 +3155,19 @@
         rmemory_acoustic_dux_dz = ZERO
 
         if(time_stepping_scheme == 2)then
-          allocate(rmemory_potential_acoust_LDDRK(2,NGLLX,NGLLZ,nspec_PML),stat=ier)
+          allocate(rmemory_potential_acoustic_LDDRK(2,NGLLX,NGLLZ,nspec_PML),stat=ier)
           if(ier /= 0) stop 'error: not enough memory to allocate array rmemory_potential_acoustic'
           allocate(rmemory_acoustic_dux_dx_LDDRK(NGLLX,NGLLZ,nspec_PML,2),stat=ier)
           if(ier /= 0) stop 'error: not enough memory to allocate array rmemory_acoustic_dux_dx'
           allocate(rmemory_acoustic_dux_dz_LDDRK(NGLLX,NGLLZ,nspec_PML,2),stat=ier)
           if(ier /= 0) stop 'error: not enough memory to allocate array rmemory_acoustic_dux_dz'
         else
-          allocate(rmemory_potential_acoust_LDDRK(1,1,1,1),stat=ier)
+          allocate(rmemory_potential_acoustic_LDDRK(1,1,1,1),stat=ier)
           allocate(rmemory_acoustic_dux_dx_LDDRK(1,1,1,1),stat=ier)
           allocate(rmemory_acoustic_dux_dz_LDDRK(1,1,1,1),stat=ier)
         endif
 
-        rmemory_potential_acoust_LDDRK = ZERO
+        rmemory_potential_acoustic_LDDRK = ZERO
         rmemory_acoustic_dux_dx_LDDRK = ZERO
         rmemory_acoustic_dux_dz_LDDRK = ZERO
 
@@ -3200,7 +3200,7 @@
       allocate(rmemory_acoustic_dux_dx(1,1,1,1))
       allocate(rmemory_acoustic_dux_dz(1,1,1,1))
 
-      allocate(rmemory_potential_acoust_LDDRK(1,1,1,1))
+      allocate(rmemory_potential_acoustic_LDDRK(1,1,1,1))
       allocate(rmemory_acoustic_dux_dx_LDDRK(1,1,1,1))
       allocate(rmemory_acoustic_dux_dz_LDDRK(1,1,1,1))
 
@@ -5189,7 +5189,7 @@ if(coupled_elastic_poro) then
                K_x_store,K_z_store,d_x_store,d_z_store,alpha_x_store,alpha_z_store,&
                rmemory_potential_acoustic,&
                rmemory_acoustic_dux_dx,rmemory_acoustic_dux_dz,&
-               rmemory_potential_acoust_LDDRK,alpha_LDDRK,beta_LDDRK,c_LDDRK, &
+               rmemory_potential_acoustic_LDDRK,alpha_LDDRK,beta_LDDRK,c_LDDRK, &
                rmemory_acoustic_dux_dx_LDDRK,rmemory_acoustic_dux_dz_LDDRK,&
                deltat,PML_BOUNDARY_CONDITIONS,STACEY_BOUNDARY_CONDITIONS)
 
@@ -5233,7 +5233,7 @@ if(coupled_elastic_poro) then
                K_x_store,K_z_store,d_x_store,d_z_store,alpha_x_store,alpha_z_store,&
                rmemory_potential_acoustic,&
                rmemory_acoustic_dux_dx,rmemory_acoustic_dux_dz,&
-               rmemory_potential_acoust_LDDRK,alpha_LDDRK,beta_LDDRK,c_LDDRK, &
+               rmemory_potential_acoustic_LDDRK,alpha_LDDRK,beta_LDDRK,c_LDDRK, &
                rmemory_acoustic_dux_dx_LDDRK,rmemory_acoustic_dux_dz_LDDRK,&
 !               deltat,PML_BOUNDARY_CONDITIONS)
                deltat,.false.,STACEY_BOUNDARY_CONDITIONS,b_potential_dot_acoustic)


### PR DESCRIPTION
--error with using LDDRK in acoustic simulation with PML
--modify one variable name in specfem2D.F90 with changing rmemory_potential_acoust_LDDRK to rmemory_potential_acoustic_LDDRK

This modification will generate different results if compared with Robot, since I have fix one error.
