### PR TITLE
Fix call to MPI_RECV.

### DIFF
--- a/src/specfem2D/assemble_MPI.F90
+++ b/src/specfem2D/assemble_MPI.F90
@@ -162,7 +162,7 @@
           2*nibool_interfaces_poroelastic(num_interface), &
           MPI_DOUBLE_PRECISION, &
           my_neighbours(num_interface), 11, &
-          MPI_COMM_WORLD, msg_status(1), ier)
+          MPI_COMM_WORLD, msg_status, ier)
 
      ipoin = 0
      do i = 1, nibool_interfaces_acoustic(num_interface)


### PR DESCRIPTION
The status argument should be an array, not the first element of one.
This is only a problem when compiling against the MPI module, as it
contains stricter type-checking.
