### PR TITLE
remove module only in subprograms

### DIFF
--- a/DATA/Par_file
+++ b/DATA/Par_file
@@ -10,7 +10,7 @@ NOISE_TOMOGRAPHY                = 0  # 0 = earthquake simulation, 1/2/3 = noise 
 SAVE_FORWARD                    = .false. # save the last frame, needed for adjoint simulation
 
 # parameters concerning partitioning
-nproc                           = 1              # number of processes
+nproc                           = 8              # number of processes
 partitioning_method             = 3              # SCOTCH = 3, ascending order (very bad idea) = 1
 
 ngnod                           = 9              # number of control nodes per element (4 or 9)
@@ -76,7 +76,7 @@ NSTEP_BETWEEN_OUTPUT_IMAGES     = 100            # every how many time steps we 
 cutsnaps                        = 1.             # minimum amplitude kept in % for the JPEG and PostScript snapshots; amplitudes below that are muted
 #### for JPEG color images ####
 output_color_image              = .true.         # output JPEG color image of the results every NSTEP_BETWEEN_OUTPUT_IMAGES time steps or not
-imagetype_JPEG                  = 2              # display 1=displ_Ux 2=displ_Uz 3=displ_norm 4=veloc_Vx 5=veloc_Vz 6=veloc_norm 7=accel_Ax 8=accel_Az 9=accel_norm 10=pressure
+imagetype_JPEG                  = 10              # display 1=displ_Ux 2=displ_Uz 3=displ_norm 4=veloc_Vx 5=veloc_Vz 6=veloc_norm 7=accel_Ax 8=accel_Az 9=accel_norm 10=pressure
 factor_subsample_image          = 1.0d0          # (double precision) factor to subsample color images output by the code (useful for very large models)
 USE_CONSTANT_MAX_AMPLITUDE      = .false.        # by default the code normalizes each image independently to its maximum; use this option to use the global maximum below instead
 CONSTANT_MAX_AMPLITUDE_TO_USE   = 1.17d4         # constant maximum amplitude to use for all color images if the above USE_CONSTANT_MAX_AMPLITUDE option is true
@@ -85,7 +85,7 @@ DRAW_SOURCES_AND_RECEIVERS      = .true.         # display sources as orange cro
 DRAW_WATER_IN_BLUE              = .true.         # display acoustic layers as constant blue in JPEG images, because they likely correspond to water in the case of ocean acoustics or in the case of offshore oil industry experiments (if off, display them as greyscale, as for elastic or poroelastic elements, for instance for acoustic-only oil industry models of solid media)
 USE_SNAPSHOT_NUMBER_IN_FILENAME = .false.        # use snapshot number in the file name of JPEG color snapshots instead of the time step (for instance to create movies in an easier way later)
 #### for PostScript snapshots ####
-output_postscript_snapshot      = .true.         # output Postscript snapshot of the results every NSTEP_BETWEEN_OUTPUT_IMAGES time steps or not
+output_postscript_snapshot      = .false.         # output Postscript snapshot of the results every NSTEP_BETWEEN_OUTPUT_IMAGES time steps or not
 imagetype_postscript            = 1              # display 1=displ vector 2=veloc vector 3=accel vector; small arrows are displayed for the vectors
 meshvect                        = .true.         # display mesh on PostScript plots or not
 modelvect                       = .false.        # display velocity model on PostScript plots or not

--- a/DATA/Par_file
+++ b/DATA/Par_file
@@ -10,7 +10,7 @@ NOISE_TOMOGRAPHY                = 0  # 0 = earthquake simulation, 1/2/3 = noise 
 SAVE_FORWARD                    = .false. # save the last frame, needed for adjoint simulation
 
 # parameters concerning partitioning
-nproc                           = 8              # number of processes
+nproc                           = 1              # number of processes
 partitioning_method             = 3              # SCOTCH = 3, ascending order (very bad idea) = 1
 
 ngnod                           = 9              # number of control nodes per element (4 or 9)
@@ -76,7 +76,7 @@ NSTEP_BETWEEN_OUTPUT_IMAGES     = 100            # every how many time steps we 
 cutsnaps                        = 1.             # minimum amplitude kept in % for the JPEG and PostScript snapshots; amplitudes below that are muted
 #### for JPEG color images ####
 output_color_image              = .true.         # output JPEG color image of the results every NSTEP_BETWEEN_OUTPUT_IMAGES time steps or not
-imagetype_JPEG                  = 10              # display 1=displ_Ux 2=displ_Uz 3=displ_norm 4=veloc_Vx 5=veloc_Vz 6=veloc_norm 7=accel_Ax 8=accel_Az 9=accel_norm 10=pressure
+imagetype_JPEG                  = 2              # display 1=displ_Ux 2=displ_Uz 3=displ_norm 4=veloc_Vx 5=veloc_Vz 6=veloc_norm 7=accel_Ax 8=accel_Az 9=accel_norm 10=pressure
 factor_subsample_image          = 1.0d0          # (double precision) factor to subsample color images output by the code (useful for very large models)
 USE_CONSTANT_MAX_AMPLITUDE      = .false.        # by default the code normalizes each image independently to its maximum; use this option to use the global maximum below instead
 CONSTANT_MAX_AMPLITUDE_TO_USE   = 1.17d4         # constant maximum amplitude to use for all color images if the above USE_CONSTANT_MAX_AMPLITUDE option is true
@@ -85,7 +85,7 @@ DRAW_SOURCES_AND_RECEIVERS      = .true.         # display sources as orange cro
 DRAW_WATER_IN_BLUE              = .true.         # display acoustic layers as constant blue in JPEG images, because they likely correspond to water in the case of ocean acoustics or in the case of offshore oil industry experiments (if off, display them as greyscale, as for elastic or poroelastic elements, for instance for acoustic-only oil industry models of solid media)
 USE_SNAPSHOT_NUMBER_IN_FILENAME = .false.        # use snapshot number in the file name of JPEG color snapshots instead of the time step (for instance to create movies in an easier way later)
 #### for PostScript snapshots ####
-output_postscript_snapshot      = .false.         # output Postscript snapshot of the results every NSTEP_BETWEEN_OUTPUT_IMAGES time steps or not
+output_postscript_snapshot      = .true.         # output Postscript snapshot of the results every NSTEP_BETWEEN_OUTPUT_IMAGES time steps or not
 imagetype_postscript            = 1              # display 1=displ vector 2=veloc vector 3=accel vector; small arrows are displayed for the vectors
 meshvect                        = .true.         # display mesh on PostScript plots or not
 modelvect                       = .false.        # display velocity model on PostScript plots or not

--- a/flags.guess
+++ b/flags.guess
@@ -55,7 +55,7 @@ case $FC in
         # GNU gfortran
         #
         if test x"$DEF_FFLAGS" = x; then
-            DEF_FFLAGS="-std=f2003 -fimplicit-none -frange-check -O2 -fmax-errors=10 -pedantic -pedantic-errors -Waliasing -Wampersand -Wcharacter-truncation -Wline-truncation -Wsurprising -Wno-tabs -Wunderflow -ffpe-trap=invalid,zero,overflow "
+            DEF_FFLAGS="-std=f2003 -fimplicit-none -frange-check -O2 -fmax-errors=10 -pedantic -pedantic-errors -Waliasing -Wampersand -Wcharacter-truncation -Wline-truncation -Wsurprising -Wno-tabs -Wunderflow -ffpe-trap=invalid,zero,overflow -Wunused -Werror "
         fi
         # useful for debugging: add   -ggdb -fbacktrace -fbounds-check
         # useful to track loss of accuracy because of automatic double to single precision conversion:  -Wconversion  (this may generate many warnings...)

--- a/src/specfem2D/acoustic_cuda.f90
+++ b/src/specfem2D/acoustic_cuda.f90
@@ -53,7 +53,6 @@ subroutine compute_forces_acoustic_GPU()
 
   implicit none
 
-  real, dimension(3) :: norm
 
   ! local parameters
   integer:: iphase

--- a/src/specfem2D/acoustic_forcing_boundary.f90
+++ b/src/specfem2D/acoustic_forcing_boundary.f90
@@ -48,17 +48,14 @@
 
   subroutine acoustic_forcing_boundary()
 
-  use specfem_par, only: it,deltat,t0,displ_x,displ_z,iglob,coord,nglob
+  use specfem_par
 
   implicit none
 
-  include "constants.h"
-
-
 ! local variables
   real, parameter :: pigrec = 3.1415927
-  real :: alpha,tho,A,c,x,delayed,delta_x
-  integer :: forcing_type,k,ngoce_time_step,n_models,kk,ll
+  real :: alpha,tho,A,c,delayed,delta_x
+  integer :: forcing_type,k,ngoce_time_step,n_models,kk,ll,iglob
 
   double precision, dimension(:), allocatable :: goce_time,distance
   double precision, dimension(:,:), allocatable ::syn

--- a/src/specfem2D/assemble_MPI.F90
+++ b/src/specfem2D/assemble_MPI.F90
@@ -64,7 +64,7 @@
                               ibool_interfaces_acoustic,ibool_interfaces_elastic, &
                               ibool_interfaces_poroelastic, &
                               nibool_interfaces_acoustic,nibool_interfaces_elastic, &
-                              nibool_interfaces_poroelastic,my_neighbours,i,ier
+                              nibool_interfaces_poroelastic,my_neighbours,ier
 
 
   implicit none
@@ -82,7 +82,7 @@
   integer :: npoin_val3
   real(kind=CUSTOM_REAL), dimension(npoin_val3), intent(inout) :: array_val3,array_val4
 
-  integer  :: ipoin, num_interface
+  integer  :: ipoin, num_interface,i
 ! there are now two different mass matrices for the elastic case
 ! in order to handle the C deltat / 2 contribution of the Stacey conditions to the mass matrix
   double precision, dimension(max_ibool_interfaces_size_ac+2*max_ibool_interfaces_size_el+&
@@ -219,7 +219,7 @@
                          tab_requests_send_recv_acoustic, &
                          buffer_send_faces_vector_ac, &
                          buffer_recv_faces_vector_ac, &
-                         my_neighbours,myrank,iglob,ier
+                         my_neighbours,myrank,ier
 
   implicit none
 
@@ -231,7 +231,7 @@
   real(kind=CUSTOM_REAL), dimension(nglob), intent(inout) :: array_val1
 
   ! local parameters
-  integer  :: ipoin, num_interface,iinterface
+  integer  :: ipoin, num_interface,iinterface, iglob
 
   ! initializes buffers
   buffer_send_faces_vector_ac(:,:) = 0._CUSTOM_REAL
@@ -426,22 +426,16 @@
 
   use mpi
 
-  use specfem_par, only: nglob, &
-                         ninterface, ninterface_poroelastic,inum_interfaces_poroelastic, &
-                         max_interface_size, max_ibool_interfaces_size_po,&
-                         ibool_interfaces_poroelastic, nibool_interfaces_poroelastic, &
-                         tab_requests_send_recv_poro,buffer_send_faces_vector_pos,buffer_send_faces_vector_pow, &
-                         buffer_recv_faces_vector_pos,buffer_recv_faces_vector_pow, my_neighbours,ier,i
+  use specfem_par
 
 
   implicit none
 
-  include 'constants.h'
   include 'precision.h'
 
   real(kind=CUSTOM_REAL), dimension(NDIM,nglob), intent(inout) :: array_val3,array_val4
 
-  integer  :: ipoin, num_interface, iinterface
+  integer  :: ipoin, num_interface, iinterface,i
 
   do iinterface = 1, ninterface_poroelastic
 

--- a/src/specfem2D/attenuation_model.f90
+++ b/src/specfem2D/attenuation_model.f90
@@ -41,19 +41,16 @@
 !
 !========================================================================
 
-  subroutine attenuation_model(QKappa_attenuation,Qmu_attenuation)
+  subroutine attenuation_model(QKappa_att,QMu_att)
 
 ! define the attenuation constants
 
-  use specfem_par, only :  N_SLS, f0_attenuation,tau_epsilon_nu1,tau_epsilon_nu2,inv_tau_sigma_nu1_sent,phi_nu1_sent, &
-                           inv_tau_sigma_nu2_sent,phi_nu2_sent,Mu_nu1_sent,Mu_nu2_sent
+  use specfem_par
 
 
   implicit none
 
-  include "constants.h"
-
-  double precision :: QKappa_attenuation,Qmu_attenuation
+  double precision :: QKappa_att,QMu_att
 
   integer :: i_sls
 
@@ -79,16 +76,16 @@
 ! We thus strongly discourage using the old routine.
   if(USE_NEW_SOLVOPT_ROUTINE) then
 
-    call determination_coef(N_SLS,QKappa_attenuation,f0_attenuation,f_min_attenuation,f_max_attenuation, &
+    call determination_coef(N_SLS,QKappa_att,f0_attenuation,f_min_attenuation,f_max_attenuation, &
                                   tau_epsilon_nu1_d,tau_sigma_nu1)
 
-    call determination_coef(N_SLS,Qmu_attenuation,f0_attenuation,f_min_attenuation,f_max_attenuation, &
+    call determination_coef(N_SLS,QMu_att,f0_attenuation,f_min_attenuation,f_max_attenuation, &
                                   tau_epsilon_nu2_d,tau_sigma_nu2)
 
 !   print *
 !   print *,'with new SolvOpt:'
 !   print *
-!   print *,'N_SLS, QKappa_attenuation, Qmu_attenuation = ',N_SLS, QKappa_attenuation, Qmu_attenuation
+!   print *,'N_SLS, QKappa_att, QMu_att = ',N_SLS, QKappa_att, QMu_att
 !   print *,'f0_attenuation,f_min_attenuation,f_max_attenuation = ',f0_attenuation,f_min_attenuation,f_max_attenuation
 !   print *,'tau_epsilon_nu1 = ',tau_epsilon_nu1_d
 !   print *,'tau_sigma_nu1 = ',tau_sigma_nu1
@@ -100,13 +97,13 @@
 
 ! call a C function that computes attenuation parameters (function in file "attenuation_compute_param.c";
 ! a main can be found in UTILS/attenuation directory).
-    call attenuation_compute_param(N_SLS, QKappa_attenuation, Qmu_attenuation, &
+    call attenuation_compute_param(N_SLS, QKappa_att, QMu_att, &
          f_min_attenuation,f_max_attenuation,tau_sigma_nu1, tau_sigma_nu2, tau_epsilon_nu1_d, tau_epsilon_nu2_d)
 
 !   print *
 !   print *,'with old C routine:'
 !   print *
-!   print *,'N_SLS, QKappa_attenuation, Qmu_attenuation = ',N_SLS, QKappa_attenuation, Qmu_attenuation
+!   print *,'N_SLS, QKappa_att, QMu_att = ',N_SLS, QKappa_att, QMu_att
 !   print *,'f0_attenuation,f_min_attenuation,f_max_attenuation = ',f0_attenuation,f_min_attenuation,f_max_attenuation
 !   print *,'tau_epsilon_nu1 = ',tau_epsilon_nu1_d
 !   print *,'tau_sigma_nu1 = ',tau_sigma_nu1

--- a/src/specfem2D/compute_arrays_source.f90
+++ b/src/specfem2D/compute_arrays_source.f90
@@ -129,27 +129,23 @@
 ! ------------------------------------------------------------------------------------------------------
 
 
-  subroutine compute_arrays_adj_source(xi_receiver,gamma_receiver)
+  subroutine compute_arrays_adj_source(xi_rec,gamma_rec)
 
  use constants
- use specfem_par, only: source_adjointe,seismotype,adj_source_file,adj_sourcearray, &
-                        xigll,zigll,NSTEP,irec_local
+ use specfem_par
 
  implicit none
 
 
-  double precision xi_receiver, gamma_receiver
 
-  double precision :: hxir(NGLLX), hpxir(NGLLX), hgammar(NGLLZ), hpgammar(NGLLZ)
-  real(kind=CUSTOM_REAL) :: adj_src_s(NSTEP,3)
+  double precision xi_rec, gamma_rec
 
-  integer icomp, itime, i, k, ios
+  integer icomp, itime, i, k
   double precision :: junk
   character(len=3) :: comp(3)
-  character(len=150) :: filename
 
-  call lagrange_any(xi_receiver,NGLLX,xigll,hxir,hpxir)
-  call lagrange_any(gamma_receiver,NGLLZ,zigll,hgammar,hpgammar)
+  call lagrange_any(xi_rec,NGLLX,xigll,hxir,hpxir)
+  call lagrange_any(gamma_rec,NGLLZ,zigll,hgammar,hpgammar)
 
   adj_sourcearray(:,:,:,:) = 0.
 

--- a/src/specfem2D/compute_curl_one_element.f90
+++ b/src/specfem2D/compute_curl_one_element.f90
@@ -41,19 +41,21 @@
 !
 !========================================================================
 
-  subroutine compute_curl_one_element()
+  subroutine compute_curl_one_element(ispec)
 
   ! compute curl in (poro)elastic elements (for rotational study)
 
   use specfem_par, only: curl_element,displ_elastic, &
                          displs_poroelastic,elastic,poroelastic, &
                          xix,xiz,gammax,gammaz,ibool,hprime_xx,hprime_zz, &
-                         nspec,nglob_elastic,nglob_poroelastic,ispec,i,j,k
+                         nspec,nglob_elastic,nglob_poroelastic
 
 
   implicit none
 
   include "constants.h"
+
+  integer ispec
 
   ! jacobian
   real(kind=CUSTOM_REAL) :: xixl,xizl,gammaxl,gammazl
@@ -61,6 +63,7 @@
   ! spatial derivatives
   real(kind=CUSTOM_REAL) :: dux_dxi,dux_dgamma,duz_dxi,duz_dgamma
   real(kind=CUSTOM_REAL) :: duz_dxl,dux_dzl
+  integer :: i,j,k
 
   if(elastic(ispec)) then
 

--- a/src/specfem2D/compute_energy.f90
+++ b/src/specfem2D/compute_energy.f90
@@ -45,44 +45,16 @@
 
 ! compute kinetic and potential energy in the solid (acoustic elements are excluded)
 
-  use specfem_par, only : displ_elastic,veloc_elastic, &
-                          displs_poroelastic,velocs_poroelastic, &
-                          displw_poroelastic,velocw_poroelastic, &
-                          xix,xiz,gammax,gammaz,jacobian,ibool,elastic,poroelastic,hprime_xx,hprime_zz, &
-                          AXISYM,nglob,coord,is_on_the_axis,hprimeBar_xx, &
-                          nspec,nglob_acoustic,nglob_elastic,nglob_poroelastic, &
-                          assign_external_model,kmato,poroelastcoef,density,porosity,tortuosity, &
-                          vpext,vsext,rhoext,c11ext,c13ext,c15ext,c33ext,c35ext,c55ext,c12ext,c23ext,c25ext, &
-                          anisotropic,anisotropy,wxgll,wzgll,numat, &
-                          pressure_element,vector_field_element,e1,e11, &
-                          potential_dot_acoustic,potential_dot_dot_acoustic, &
-                          ATTENUATION_VISCOELASTIC_SOLID,Mu_nu1,Mu_nu2,N_SLS,p_sv,kinetic_energy,potential_energy, &
-                          potential_dot_gravitoacoustic,potential_dot_dot_gravitoacoustic,acoustic,gravitoacoustic, &
-                          gravityext,potential_dot_gravito,nglob_gravitoacoustic,ispec
+  use specfem_par
 
   implicit none
 
-  include "constants.h"
 
 ! local variables
-  integer :: i,j,k
+  integer :: i,j,k,ispec
 
-! spatial derivatives
-  real(kind=CUSTOM_REAL) :: dux_dxi,dux_dgamma,duz_dxi,duz_dgamma
-  real(kind=CUSTOM_REAL) :: dux_dxl,duz_dxl,dux_dzl,duz_dzl
-  real(kind=CUSTOM_REAL) :: dwx_dxi,dwx_dgamma,dwz_dxi,dwz_dgamma
-  real(kind=CUSTOM_REAL) :: dwx_dxl,dwz_dxl,dwx_dzl,dwz_dzl
+  real(kind=CUSTOM_REAL) :: cpl,csl,kappal
 
-! jacobian
-  real(kind=CUSTOM_REAL) :: xixl,xizl,gammaxl,gammazl,jacobianl
-
-  real(kind=CUSTOM_REAL) :: cpl,csl,rhol,mul_unrelaxed_elastic,lambdal_unrelaxed_elastic, &
-    lambdaplus2mu_unrelaxed_elastic,kappal
-  real(kind=CUSTOM_REAL) :: mul_s,kappal_s,rhol_s
-  real(kind=CUSTOM_REAL) :: kappal_f,rhol_f
-  real(kind=CUSTOM_REAL) :: mul_fr,kappal_fr,phil,tortl
-  real(kind=CUSTOM_REAL) :: D_biot,H_biot,C_biot,M_biot,rhol_bar
-  real(kind=CUSTOM_REAL) :: mul_G,lambdal_G,lambdalplus2mul_G
 
   kinetic_energy = ZERO
   potential_energy = ZERO
@@ -294,11 +266,11 @@
       ! and pressure is: p = - Chi_dot_dot  (Chi_dot_dot being the time second derivative of Chi).
 
       ! compute pressure in this element
-      call compute_pressure_one_element()
+      call compute_pressure_one_element(ispec)
 
       ! compute velocity vector field in this element
       call compute_vector_one_element(potential_dot_acoustic,potential_dot_gravitoacoustic, &
-                              potential_dot_gravito,veloc_elastic,velocs_poroelastic)
+                              potential_dot_gravito,veloc_elastic,velocs_poroelastic,ispec)
 
       ! get density of current spectral element
       lambdal_unrelaxed_elastic = poroelastcoef(1,1,kmato(ispec))

--- a/src/specfem2D/compute_forces_acoustic.f90
+++ b/src/specfem2D/compute_forces_acoustic.f90
@@ -67,7 +67,7 @@
                          rmemory_acoustic_dux_dx,rmemory_acoustic_dux_dz,&
                          rmemory_potential_acoustic_LDDRK,alpha_LDDRK,beta_LDDRK,c_LDDRK, &
                          rmemory_acoustic_dux_dx_LDDRK,rmemory_acoustic_dux_dz_LDDRK,&
-                         deltat,STACEY_BOUNDARY_CONDITIONS,ispec,i,j,k,iglob,ispecabs
+                         deltat,STACEY_BOUNDARY_CONDITIONS
 
   implicit none
 
@@ -84,6 +84,7 @@
 !---
 
   integer :: ispec_PML,ibegin,iend,jbegin,jend
+  integer :: ispec,i,j,k,iglob,ispecabs
 
 ! spatial derivatives
   real(kind=CUSTOM_REAL) :: dux_dxi,dux_dgamma,dux_dxl,dux_dzl

--- a/src/specfem2D/compute_forces_poro_fluid.f90
+++ b/src/specfem2D/compute_forces_poro_fluid.f90
@@ -64,7 +64,7 @@
                          nspec_left,nspec_right,nspec_bottom,nspec_top,ib_left,ib_right,ib_bottom,ib_top,freq0,Q0, &
                          e11_LDDRK,e13_LDDRK,alpha_LDDRK,beta_LDDRK, &
                          e11_initial_rk,e13_initial_rk,e11_force_RK, e13_force_RK, &
-                         stage_time_scheme,i_stage,i_source
+                         stage_time_scheme,i_stage
 
   implicit none
 
@@ -78,7 +78,7 @@
 !--- local variables
 !---
 
-  integer :: ispec,i,j,k,iglob,ispecabs,ibegin,iend,jbegin,jend,irec,irec_local
+  integer :: ispec,i,j,k,iglob,ispecabs,ibegin,iend,jbegin,jend,irec,irec_local,i_source
   real(kind=CUSTOM_REAL) :: weight_rk
   real(kind=CUSTOM_REAL) :: e11_sum,e13_sum
   integer :: i_sls

--- a/src/specfem2D/compute_forces_poro_solid.f90
+++ b/src/specfem2D/compute_forces_poro_solid.f90
@@ -64,14 +64,14 @@
                          nspec_left,nspec_right,nspec_bottom,nspec_top,ib_left,ib_right,ib_bottom,ib_top,freq0,Q0,&
                          e11_LDDRK,e13_LDDRK,alpha_LDDRK,beta_LDDRK, &
                          e11_initial_rk,e13_initial_rk,e11_force_RK, e13_force_RK, &
-                         stage_time_scheme,i_stage, i_source
+                         stage_time_scheme,i_stage
 
   implicit none
 
   include "constants.h"
 
   real(kind=CUSTOM_REAL) :: e11_sum,e13_sum
-  integer :: i_sls
+  integer :: i_sls, i_source
 
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLZ,nspec) ::dux_dxl_n,duz_dzl_n,duz_dxl_n,dux_dzl_n, &
                                                          !nsub1 denote discrete time step n-1

--- a/src/specfem2D/compute_pressure.f90
+++ b/src/specfem2D/compute_pressure.f90
@@ -45,24 +45,17 @@
 
 ! compute pressure in acoustic elements and in elastic elements
 
-  use specfem_par, only: potential_dot_dot_acoustic,potential_dot_dot_gravitoacoustic,displ_elastic,&
-                         displs_poroelastic,displw_poroelastic,acoustic,gravitoacoustic,elastic,poroelastic,vector_field_display, &
-                         xix,xiz,gammax,gammaz,ibool,hprime_xx,hprime_zz,nspec, &
-                         AXISYM,coord,jacobian,is_on_the_axis,hprimeBar_xx, &
-                         nglob,nglob_acoustic,nglob_gravitoacoustic,nglob_elastic,nglob_poroelastic,assign_external_model, &
-                         numat,kmato,density,porosity,tortuosity,poroelastcoef,vpext,vsext,rhoext, &
-                         c11ext,c13ext,c15ext,c33ext,c35ext,c55ext,c12ext,c23ext,c25ext,anisotropic,anisotropy,e1,e11, &
-                         ATTENUATION_VISCOELASTIC_SOLID,Mu_nu1,Mu_nu2,N_SLS,i,j,ispec,iglob,pressure_element
+  use specfem_par
 
   implicit none
 
-  include "constants.h"
+  integer i,j,ispec,iglob
 
 ! loop over spectral elements
   do ispec = 1,nspec
 
 ! compute pressure in this element
-    call compute_pressure_one_element()
+    call compute_pressure_one_element(ispec)
 
 ! use vector_field_display as temporary storage, store pressure in its second component
     do j = 1,NGLLZ
@@ -80,24 +73,17 @@
 !=====================================================================
 !
 
-  subroutine compute_pressure_one_element()
+  subroutine compute_pressure_one_element(ispec)
 
 
 ! compute pressure in acoustic elements and in elastic elements
 
-  use specfem_par, only: pressure_element,potential_dot_dot_acoustic, &
-                         potential_dot_dot_gravitoacoustic,displ_elastic,&
-                         displs_poroelastic,displw_poroelastic,acoustic,gravitoacoustic,elastic,poroelastic,&
-                         xix,xiz,gammax,gammaz,ibool,hprime_xx,hprime_zz,nspec, &
-                         AXISYM,nglob,coord,jacobian,is_on_the_axis,hprimeBar_xx, &
-                         nglob_acoustic,nglob_gravitoacoustic,nglob_elastic,nglob_poroelastic,assign_external_model, &
-                         numat,kmato,density,porosity,tortuosity,poroelastcoef,vpext,vsext,rhoext, &
-                         c11ext,c13ext,c15ext,c33ext,c35ext,c55ext,c12ext,c23ext,c25ext,anisotropic,anisotropy,ispec,e1,e11, &
-                         ATTENUATION_VISCOELASTIC_SOLID,Mu_nu1,Mu_nu2,N_SLS
+  use specfem_par
 
   implicit none
 
-  include "constants.h"
+
+  integer ispec
 
   real(kind=CUSTOM_REAL) :: e1_sum,e11_sum
 
@@ -106,29 +92,14 @@
 ! local variables
   integer :: i,j,k,iglob
 
-! jacobian
-  real(kind=CUSTOM_REAL) :: xixl,xizl,gammaxl,gammazl
+  real(kind=CUSTOM_REAL) :: sigma_yy !! ,sigmap
+  real(kind=CUSTOM_REAL) :: sigma_thetatheta
 
-! spatial derivatives
-  real(kind=CUSTOM_REAL) :: dux_dxi,dux_dgamma,duz_dxi,duz_dgamma
-  real(kind=CUSTOM_REAL) :: dux_dxl,duz_dxl,dux_dzl,duz_dzl
-  real(kind=CUSTOM_REAL) :: sigma_xx,sigma_yy,sigma_zz !! ,sigmap
-  real(kind=CUSTOM_REAL) :: sigma_thetatheta,xxi
-  real(kind=CUSTOM_REAL) :: dwx_dxi,dwx_dgamma,dwz_dxi,dwz_dgamma
-  real(kind=CUSTOM_REAL) :: dwx_dxl,dwz_dzl
 
 ! material properties of the elastic medium
-  real(kind=CUSTOM_REAL) :: mul_unrelaxed_elastic,lambdal_unrelaxed_elastic,lambdaplus2mu_unrelaxed_elastic,denst
+  real(kind=CUSTOM_REAL) :: denst
   real(kind=CUSTOM_REAL) :: mul_relaxed_viscoelastic,lambdal_relaxed_viscoelastic,lambdalplus2mul_relaxed_viscoel,cpl,csl
 
-  real(kind=CUSTOM_REAL) :: mul_s,kappal_s,rhol_s
-  real(kind=CUSTOM_REAL) :: kappal_f,rhol_f
-  real(kind=CUSTOM_REAL) :: mul_fr,kappal_fr,phil,tortl
-  real(kind=CUSTOM_REAL) :: D_biot,H_biot,C_biot,M_biot,rhol_bar
-  real(kind=CUSTOM_REAL) :: mul_G,lambdal_G,lambdalplus2mul_G
-
-! for anisotropy
-  double precision ::  c11,c15,c13,c33,c35,c55,c12,c23,c25
 
 ! if elastic element
 !

--- a/src/specfem2D/createnum_fast.f90
+++ b/src/specfem2D/createnum_fast.f90
@@ -45,7 +45,7 @@
 
 ! same as subroutine "createnum_slow" but with a faster algorithm
 
-  use specfem_par, only: knods,ibool,shape2D,coorg,nglob,npgeo,nspec,ngnod,myrank,i,j
+  use specfem_par, only: knods,ibool,shape2D,coorg,nglob,npgeo,nspec,ngnod,myrank
   implicit none
 
   include "constants.h"
@@ -55,7 +55,7 @@
   logical, dimension(:), allocatable :: ifseg
   double precision, dimension(:), allocatable :: xp,yp,work
 
-  integer :: ispec,nseg,ioff,iseg,ig
+  integer :: ispec,nseg,ioff,iseg,ig,i,j
   integer :: nxyz,ntot,ieoff,ilocnum,iy,ix,in,nnum
 
   double precision :: xmaxval,xminval,ymaxval,yminval,xtol,xtypdist

--- a/src/specfem2D/finalize_simulation.F90
+++ b/src/specfem2D/finalize_simulation.F90
@@ -9,6 +9,9 @@ subroutine finalize_simulation()
 
   implicit none
 
+integer i,ispec,j,iglob
+
+
 #ifdef USE_MPI
   include "precision.h"
 #endif

--- a/src/specfem2D/invert_mass_matrix.F90
+++ b/src/specfem2D/invert_mass_matrix.F90
@@ -66,13 +66,13 @@
                                 K_x_store,K_z_store,is_PML,&
                                 AXISYM,nglob,is_on_the_axis,coord,wxglj,xiglj, &
                                 d_x_store,d_z_store,PML_BOUNDARY_CONDITIONS,region_CPML, &
-                                nspec_PML,spec_to_PML,time_stepping_scheme,ispec,i,j,iglob
+                                nspec_PML,spec_to_PML,time_stepping_scheme
 
   implicit none
   include 'constants.h'
 
 
-  integer :: ibegin,iend,ispecabs,jbegin,jend
+  integer :: ibegin,iend,ispecabs,jbegin,jend,ispec,i,j,iglob
 
 
   ! local parameter

--- a/src/specfem2D/iterate_time.F90
+++ b/src/specfem2D/iterate_time.F90
@@ -9,6 +9,8 @@ subroutine iterate_time()
 
   implicit none
 
+integer i,j,ispec,i_source,iglob,irec,k
+
 #ifdef USE_MPI
   include "precision.h"
 #endif

--- a/src/specfem2D/plot_gll.f90
+++ b/src/specfem2D/plot_gll.f90
@@ -45,12 +45,12 @@
 
 ! output the Gauss-Lobatto-Legendre mesh in a gnuplot file
 
-  use specfem_par, only: knods,ibool,coorg,coord,nglob,npgeo,ngnod,nspec,ispec
+  use specfem_par, only: knods,ibool,coorg,coord,nglob,npgeo,ngnod,nspec
   implicit none
 
   include "constants.h"
 
-  integer iy,ix,iglobnum,iglobnum2,ibloc,inode
+  integer iy,ix,iglobnum,iglobnum2,ibloc,inode,ispec
 
 ! coordinates of the nodes for Gnuplot file
   integer, parameter :: MAXNGNOD = 9

--- a/src/specfem2D/plot_post.F90
+++ b/src/specfem2D/plot_post.F90
@@ -84,7 +84,7 @@
                          coorg_send_ps_free_surface,coorg_recv_ps_free_surface, &
                          d1_coorg_send_ps_vector_field,d1_coorg_recv_ps_vector_field, &
                          d2_coorg_send_ps_vector_field,d2_coorg_recv_ps_vector_field, &
-                         coorg_send_ps_vector_field,coorg_recv_ps_vector_field,US_LETTER,is_PML,i,iproc
+                         coorg_send_ps_vector_field,coorg_recv_ps_vector_field,US_LETTER,is_PML
 
   implicit none
 
@@ -113,7 +113,7 @@
              coupled_elastic_poro_glob
 
   integer  :: nspec_recv,num_spec,pointsdisp_loop
-  integer  :: nb_coorg_per_elem, nb_color_per_elem
+  integer  :: nb_coorg_per_elem, nb_color_per_elem,i,iproc
 ! to suppress useless white spaces in postscript lines
   character(len=100) :: postscript_line
   character(len=1), dimension(100) :: ch1,ch2

--- a/src/specfem2D/pml_init.F90
+++ b/src/specfem2D/pml_init.F90
@@ -67,14 +67,14 @@
 
 use specfem_par, only: myrank,SIMULATION_TYPE,SAVE_FORWARD,nspec,nglob,ibool,anyabs,nelemabs,codeabs,numabs,&
                        NELEM_PML_THICKNESS,nspec_PML,is_PML,which_PML_elem,spec_to_PML,region_CPML,&
-                       PML_interior_interface,nglob_interface,mask_ibool,read_external_mesh,ier,i,j,k,ispec,iglob
+                       PML_interior_interface,nglob_interface,mask_ibool,read_external_mesh,ier
 
   implicit none
   include 'constants.h'
 
   integer, dimension(nglob) ::   icorner_iglob
 
-  integer :: nspec_PML_tot,ibound,ispecabs,ncorner,i_coef
+  integer :: nspec_PML_tot,ibound,ispecabs,ncorner,i_coef,i,j,k,ispec,iglob
 
   nspec_PML = 0
 
@@ -302,9 +302,11 @@ end subroutine pml_init
 !
  subroutine determin_interface_pml_interior()
 
-  use specfem_par, only: nglob_interface,nspec,ibool,PML_interior_interface,i,j,iglob,ispec,&
+  use specfem_par, only: nglob_interface,nspec,ibool,PML_interior_interface,&
                          which_PML_elem,point_interface,read_external_mesh,mask_ibool,region_CPML,nglob
   implicit none
+
+  integer i,j,iglob,ispec
   include 'constants.h'
 
   nglob_interface = 0
@@ -426,7 +428,7 @@ end subroutine pml_init
 #endif
 
   use specfem_par, only: f0,NELEM_PML_THICKNESS,elastic,acoustic,&
-                         NSOURCES,ispec_selected_source,i_source,&
+                         NSOURCES,ispec_selected_source,&
                          nspec,kmato,density,poroelastcoef,numat,&
                          ibool,coord,is_PML,region_CPML,spec_to_PML,nspec_PML,&
                          K_x_store,K_z_store,d_x_store,d_z_store,alpha_x_store,alpha_z_store
@@ -463,7 +465,7 @@ end subroutine pml_init
   double precision :: ALPHA_MAX_PML
 
 ! material properties of the elastic medium
-  integer i,j,ispec,iglob,ispec_PML
+  integer i,j,ispec,iglob,ispec_PML,i_source
   double precision :: lambdalplus2mul_relaxed,rhol
   double precision :: d_x, d_z, K_x, K_z, alpha_x, alpha_z
 ! define an alias for y and z variable names (which are the same)

--- a/src/specfem2D/prepare_initial_field.F90
+++ b/src/specfem2D/prepare_initial_field.F90
@@ -54,13 +54,13 @@
                          nglob,numat,poroelastcoef,density,coord, &
                          anglesource_refl,c_inc,c_refl,cploc,csloc,time_offset, &
                          A_plane, B_plane, C_plane, &
-                         accel_elastic,veloc_elastic,displ_elastic,i
+                         accel_elastic,veloc_elastic,displ_elastic
 
   implicit none
   include "constants.h"
 
   ! local parameters
-  integer :: numat_local
+  integer :: numat_local,i
   double precision :: denst,lambdaplus2mu,mu,p,x0_source,z0_source
   double precision :: PP,PS,SP,SS,anglesource_abs
   double precision :: xmax, xmin, zmax, zmin,x,z,t

--- a/src/specfem2D/prepare_timerun.F90
+++ b/src/specfem2D/prepare_timerun.F90
@@ -9,6 +9,10 @@ subroutine prepare_timerun_mass_matrix()
 
   implicit none
 
+integer ispec
+! inner/outer elements in the case of an MPI simulation
+  integer :: ispec_inner,ispec_outer
+
 #ifdef USE_MPI
   include "precision.h"
 #endif
@@ -183,6 +187,8 @@ subroutine prepare_timerun_image_coloring()
   use specfem_par
 
   implicit none
+
+  integer i,j,k
 
 #ifdef USE_MPI
   include "precision.h"
@@ -453,6 +459,8 @@ subroutine prepare_timerun_pml()
 
   implicit none
 
+  integer i
+  
 #ifdef USE_MPI
   include "precision.h"
 #endif
@@ -851,6 +859,8 @@ subroutine prepare_timerun_read()
   use specfem_par
 
   implicit none
+
+  integer i,ispec,ispec2,j
 
 #ifdef USE_MPI
   include "precision.h"
@@ -1555,6 +1565,8 @@ subroutine prepare_timerun_noise()
   use specfem_par
 
   implicit none
+
+  integer i,j,iglob,ispec
 
 #ifdef USE_MPI
   include "precision.h"

--- a/src/specfem2D/prepare_timerun.F90
+++ b/src/specfem2D/prepare_timerun.F90
@@ -188,10 +188,11 @@ subroutine prepare_timerun_image_coloring()
 
   implicit none
 
-  integer i,j,k
+  integer i,j
 
 #ifdef USE_MPI
   include "precision.h"
+  integer k
 #endif
 
 

--- a/src/specfem2D/prepare_timerun_body.F90
+++ b/src/specfem2D/prepare_timerun_body.F90
@@ -9,6 +9,8 @@ subroutine prepare_timerun()
 
   implicit none
 
+integer i,j,ispec,k,iglob,irec,i_source,ispecabs, irecloc
+
 #ifdef USE_MPI
   include "precision.h"
 #endif

--- a/src/specfem2D/setup_sources_receivers.F90
+++ b/src/specfem2D/setup_sources_receivers.F90
@@ -52,14 +52,14 @@
                          nproc,myrank,xi_source,gamma_source,coorg,knods,ngnod, &
                          nrec,nrecloc,recloc,which_proc_receiver,st_xval,st_zval, &
                          xi_receiver,gamma_receiver,station_name,network_name,x_final_receiver,&
-                         z_final_receiver,iglob_source,i_source,ispec
+                         z_final_receiver,iglob_source
   implicit none
 
   include "constants.h"
 
   ! Local variables
   integer ispec_acoustic_surface
-  integer  :: ixmin, ixmax, izmin, izmax
+  integer  :: ixmin, ixmax, izmin, izmax,i_source,ispec
 #ifndef USE_MPI
   integer irec
 #endif

--- a/src/specfem2D/specfem2D_par.f90
+++ b/src/specfem2D/specfem2D_par.f90
@@ -58,7 +58,7 @@ module specfem_par
   implicit none
 
 
-  integer NSOURCES,i_source,iglobzero
+  integer NSOURCES,iglobzero
   integer, dimension(:), allocatable :: source_type,time_function_type
   double precision, dimension(:), allocatable :: x_source,z_source,xi_source,gamma_source,&
                   Mxx,Mzz,Mxz,f0,tshift_src,factor,anglesource
@@ -133,7 +133,7 @@ module specfem_par
 ! curl in an element
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLX) :: curl_element
 
-  integer :: i,j,k,it,irec,id,n,ispec,ispec2,nglob,npgeo,iglob
+  integer :: it,id,n,nglob,npgeo
   integer :: nglob_acoustic
   integer :: nglob_gravitoacoustic
   integer :: nglob_elastic
@@ -271,7 +271,7 @@ module specfem_par
     NSTEP_BETWEEN_OUTPUT_INFO,seismotype,NSTEP_BETWEEN_OUTPUT_SEISMOS,NSTEP_BETWEEN_OUTPUT_IMAGES, &
     NSTEP_BETWEEN_OUTPUT_WAVE_DUMPS,subsamp_seismos,imagetype_JPEG,imagetype_wavefield_dumps
   integer :: numat,ngnod,nspec,pointsdisp, &
-    nelemabs,nelem_acforcing,nelem_acoustic_surface,ispecabs,UPPER_LIMIT_DISPLAY,NELEM_PML_THICKNESS
+    nelemabs,nelem_acforcing,nelem_acoustic_surface,UPPER_LIMIT_DISPLAY,NELEM_PML_THICKNESS
 
   logical interpol,meshvect,modelvect,boundvect,assign_external_model,initialfield, &
     output_grid_ASCII,output_grid_Gnuplot,ATTENUATION_VISCOELASTIC_SOLID,output_postscript_snapshot,output_color_image, &
@@ -543,7 +543,7 @@ module specfem_par
 
   integer  :: ixmin, ixmax, izmin, izmax
 
-  integer  :: nrecloc, irecloc
+  integer  :: nrecloc
   integer, dimension(:), allocatable :: recloc, which_proc_receiver
 
 ! to compute analytical initial plane wave field
@@ -559,7 +559,6 @@ module specfem_par
   logical :: over_critical_angle
 
 ! inner/outer elements in the case of an MPI simulation
-  integer :: ispec_inner,ispec_outer
   integer :: nglob_outer,nglob_inner
 
 ! arrays for plotpost

--- a/src/specfem2D/write_seismograms.F90
+++ b/src/specfem2D/write_seismograms.F90
@@ -45,33 +45,12 @@
 
   subroutine write_seismograms
 
-  use specfem_par, only : ibool, sisux,sisuz,siscurl,station_name,network_name, &
-                          NSTEP,nrecloc,which_proc_receiver,nrec,myrank,deltat,seismotype,st_xval,t0, &
-                          NSTEP_BETWEEN_OUTPUT_SEISMOS,seismo_offset,seismo_current,p_sv, &
-                          st_zval,SU_FORMAT,save_ASCII_seismograms, &
-                          save_binary_seismograms_single,save_binary_seismograms_double,subsamp_seismos, &
-                          recloc, ispec_selected_rec, cosrot_irec, sinrot_irec, &
-                          hxir_store, hgammar_store, &
-                          pressure_element, vector_field_element, curl_element, &
-                          acoustic, potential_acoustic, potential_dot_acoustic, potential_dot_dot_acoustic, &
-                          gravitoacoustic, potential_gravitoacoustic,&
-                          potential_dot_gravitoacoustic, potential_dot_dot_gravitoacoustic, &
-                          potential_gravito, potential_dot_gravito, potential_dot_dot_gravito, &
-                          elastic, accel_elastic, veloc_elastic, displ_elastic, &
-                          poroelastic, accels_poroelastic, velocs_poroelastic, displs_poroelastic, &
-                          acoustic,gravitoacoustic,elastic,poroelastic,vector_field_display, &
-                          xix,xiz,gammax,gammaz,ibool,hprime_xx,hprime_zz, &
-                          ispec,hprime_xx,hprime_zz, &
-                          AXISYM,is_on_the_axis,hprimeBar_xx, &
-                          nspec,nglob_acoustic,nglob_gravitoacoustic,nglob_elastic,nglob_poroelastic, &
-                          numat,kmato,density,rhoext,gravityext,assign_external_model
+  use specfem_par
 
-  include "constants.h"
+  implicit none
 
-  integer :: i, j, iglob, irecloc, irec
-  double precision :: dxd,dyd,dzd !,vxd,vyd,vzd,axd,ayd,azd
-  double precision :: valux, valuy, valuz
-  double precision :: valcurl, dcurld, hlagrange
+  integer :: i, j, iglob, irecloc, irec, ispec
+
 
 
 ! update position in seismograms
@@ -86,20 +65,20 @@
       ! compute pressure in this element if needed
       if(seismotype == 4) then
 
-        call compute_pressure_one_element()
+        call compute_pressure_one_element(ispec)
 
       else if(acoustic(ispec)) then
 
         ! for acoustic medium, compute vector field from gradient of potential for seismograms
         if(seismotype == 1 .or. seismotype == 7) then
           call compute_vector_one_element(potential_acoustic,potential_gravitoacoustic, &
-                              potential_gravito,displ_elastic,displs_poroelastic)
+                              potential_gravito,displ_elastic,displs_poroelastic,ispec)
         else if(seismotype == 2) then
           call compute_vector_one_element(potential_dot_acoustic,potential_dot_gravitoacoustic, &
-                              potential_dot_gravito,veloc_elastic,velocs_poroelastic)
+                              potential_dot_gravito,veloc_elastic,velocs_poroelastic,ispec)
         else if(seismotype == 3) then
           call compute_vector_one_element(potential_dot_dot_acoustic,potential_dot_dot_gravitoacoustic, &
-                              potential_dot_dot_gravito,accel_elastic,accels_poroelastic)
+                              potential_dot_dot_gravito,accel_elastic,accels_poroelastic,ispec)
         endif
 
       else if(gravitoacoustic(ispec)) then
@@ -107,17 +86,17 @@
         ! for acoustic medium, compute vector field from gradient of potential for seismograms
         if(seismotype == 1 .or. seismotype == 7) then
           call compute_vector_one_element(potential_acoustic,potential_gravitoacoustic, &
-                              potential_gravito,displ_elastic,displs_poroelastic)
+                              potential_gravito,displ_elastic,displs_poroelastic,ispec)
         else if(seismotype == 2) then
           call compute_vector_one_element(potential_dot_acoustic,potential_dot_gravitoacoustic, &
-                              potential_dot_gravito,veloc_elastic,velocs_poroelastic)
+                              potential_dot_gravito,veloc_elastic,velocs_poroelastic,ispec)
         else if(seismotype == 3) then
           call compute_vector_one_element(potential_dot_dot_acoustic,potential_dot_dot_gravitoacoustic, &
-                              potential_dot_dot_gravito,accel_elastic,accels_poroelastic)
+                              potential_dot_dot_gravito,accel_elastic,accels_poroelastic,ispec)
         endif
 
       else if(seismotype == 5) then
-        call compute_curl_one_element()
+        call compute_curl_one_element(ispec)
       endif
 
       ! perform the general interpolation using Lagrange polynomials


### PR DESCRIPTION
I removed some "use module, only" by "use module" in second order subprograms. This will avoid drawer effects modifying these subprograms.
I also removed loop variables (i,j,ispec...) from the module and declared them locally, to also avoid possible future mistakes.
I added some flags "-Wunused -Werror " in the configure file. 
