### PR TITLE
Add flag : USE_TRICK_FOR_BETTER_PRESSURE. Use a trick to increase accuracy of pressure seismograms in fluid (acoustic) elements:

### DIFF
--- a/DATA/Par_file
+++ b/DATA/Par_file
@@ -49,6 +49,14 @@ READ_VELOCITIES_AT_f0           = .false.
 
 # receiver set parameters for seismograms
 seismotype                      = 1              # record 1=displ 2=veloc 3=accel 4=pressure 5=curl of displ 6=the fluid potential
+# use a trick to increase accuracy of pressure seismograms in fluid (acoustic) elements:
+# use the second derivative of the source for the source time function instead of the source itself,
+# and then record -potential_acoustic() as pressure seismograms instead of -potential_dot_dot_acoustic();
+# this is mathematically equivalent, but numerically significantly more accurate because in the explicit
+# Newmark time scheme acceleration is accurate at zeroth order while displacement is accurate at second order,
+# thus in fluid elements potential_dot_dot_acoustic() is accurate at zeroth order while potential_acoustic()
+# is accurate at second order and thus contains significantly less numerical noise.
+USE_TRICK_FOR_BETTER_PRESSURE   = .true.
 NSTEP_BETWEEN_OUTPUT_SEISMOS    = 5000000        # every how many time steps we save the seismograms (costly, do not use a very small value; if you use a very large value that is larger than the total number of time steps of the run, the seismograms will automatically be saved once at the end of the run anyway)
 save_ASCII_seismograms          = .true.         # save seismograms in ASCII format or not
 save_binary_seismograms_single  = .true.         # save seismograms in single precision binary format or not (can be used jointly with ASCII above to save both)

--- a/doc/how_to_add_a_new_option_to_specfem_2D.txt
+++ b/doc/how_to_add_a_new_option_to_specfem_2D.txt
@@ -1,0 +1,67 @@
+STEPS TO ADD A NEW OPTION TO SPECFEM2D
+======================================
+
+1. Choose a flag for your option and add it to DATA/Par_file : 
+            ...
+      a_dull_integer = 42
+      MY_WONDERFUL_FLAG  = .true.
+      other_boring_float = 123.456
+            ...
+      
+2. Add this flag to src/specfem2d/read_parameter_file.F90 :
+             ...
+      logical :: MY_WONDERFUL_FLAG
+             ...
+      call read_value_integer_p(a_dull_integer, 'solver.a_dull_integer')
+      if(err_occurred() /= 0) stop 'error reading parameter 23 in Par_file'
+      call read_value_logical_p(MY_WONDERFUL_FLAG, 'solver.MY_WONDERFUL_FLAG')
+      if(err_occurred() /= 0) stop 'error reading parameter 22b in Par_file' 
+      call read_value_double_precision_p(other_boring_float, 'solver.other_boring_float')
+      if(err_occurred() /= 0) stop 'error reading parameter 22 in Par_file'
+             ...
+
+3. Write this flag in the database with src/meshfem2d/save_databases.f90
+             ...
+       write(15,*) 'a_grim_stuff'
+       write(15,*) a_grim_stuff
+
+       write(15,*) 'MY_WONDERFUL_FLAG'
+       write(15,*) MY_WONDERFUL_FLAG
+    
+       write(15,*) 'a_gloomy_flag'
+       write(15,*) a_gloomy_flag
+             ...   
+    
+5. Add it in src/specfem2d/specfem2D_par :
+             ...
+       logical :: MY_WONDERFUL_FLAG
+             ...
+
+4. Read this flag from the database with src/specfem2d/read_databases.F90 :
+             ...
+      use specfem_par, only: ...
+                             ... ,MY_WONDERFUL_FLAG, ...
+             ...
+      read(IIN,"(a80)") datlin
+      read(IIN,*) a_grim_stuff
+  
+      read(IIN,"(a80)") datlin
+      read(IIN,*) MY_WONDERFUL_FLAG
+      
+      if (MY_WONDERFUL_FLAG) write(IOUT,*) 'IT IS WONDERFUL!! IT IS SO WONDERFUL!!' !*** To test your flag
+
+      read(IIN,"(a80)") datlin
+      read(IIN,*) a_gloomy_flag
+             ...
+
+6. (Re)compile with make and run an example (don't forget to add your flag on the Par_file). At the beginning of 
+   solver's outputs you should see :
+
+      *********************
+      ****             ****
+      ****  SPECFEM2D  ****
+      ****             ****
+      *********************
+      IT IS WONDERFUL!! IT IS SO WONDERFUL!!
+
+7. Remove that ridiculous line *** on src/specfem2d/read_databases.F90 and make your flag wonderful for real

--- a/src/meshfem2D/read_parameter_file.F90
+++ b/src/meshfem2D/read_parameter_file.F90
@@ -72,7 +72,7 @@ module parameter_file
   logical :: initialfield,add_Bielak_conditions,assign_external_model, &
             READ_EXTERNAL_SEP_FILE,ATTENUATION_VISCOELASTIC_SOLID,ATTENUATION_PORO_FLUID_PART, &
             save_ASCII_seismograms,save_binary_seismograms_single,save_binary_seismograms_double,&
-            DRAW_SOURCES_AND_RECEIVERS,save_ASCII_kernels
+            DRAW_SOURCES_AND_RECEIVERS,save_ASCII_kernels,USE_TRICK_FOR_BETTER_PRESSURE
 
   double precision :: Q0,freq0
 
@@ -285,6 +285,9 @@ contains
   ! read receiver line parameters
   call read_value_integer_p(seismotype, 'solver.seismotype')
   if(err_occurred() /= 0) stop 'error reading parameter 22 in Par_file'
+  
+  call read_value_logical_p(USE_TRICK_FOR_BETTER_PRESSURE, 'solver.USE_TRICK_FOR_BETTER_PRESSURE')
+  if(err_occurred() /= 0) stop 'error reading parameter 22b in Par_file'  
 
   call read_value_integer_p(NSTEP_BETWEEN_OUTPUT_SEISMOS, 'solver.NSTEP_BETWEEN_OUTPUT_SEISMOS')
   if(err_occurred() /= 0) stop 'error reading parameter 33b in Par_file'

--- a/src/meshfem2D/save_databases.f90
+++ b/src/meshfem2D/save_databases.f90
@@ -171,6 +171,9 @@
 
     write(15,*) 'save_binary_seismograms_single save_binary_seismograms_double'
     write(15,*) save_binary_seismograms_single,save_binary_seismograms_double
+    
+    write(15,*) 'USE_TRICK_FOR_BETTER_PRESSURE'
+    write(15,*) USE_TRICK_FOR_BETTER_PRESSURE
 
     write(15,*) 'save_ASCII_kernels'
     write(15,*) save_ASCII_kernels

--- a/src/specfem2D/read_databases.F90
+++ b/src/specfem2D/read_databases.F90
@@ -60,7 +60,7 @@
                          output_grid_ASCII,output_energy,output_wavefield_dumps,use_binary_for_wavefield_dumps, &
                          ATTENUATION_VISCOELASTIC_SOLID,ATTENUATION_PORO_FLUID_PART,save_ASCII_seismograms, &
                          save_binary_seismograms_single,save_binary_seismograms_double,DRAW_SOURCES_AND_RECEIVERS, &
-                         Q0,freq0,p_sv,NSTEP,deltat,NSOURCES, &
+                         Q0,freq0,p_sv,NSTEP,deltat,NSOURCES,USE_TRICK_FOR_BETTER_PRESSURE, &
                          factor_subsample_image,USE_CONSTANT_MAX_AMPLITUDE,CONSTANT_MAX_AMPLITUDE_TO_USE, &
                          USE_SNAPSHOT_NUMBER_IN_FILENAME,DRAW_WATER_IN_BLUE,US_LETTER, &
                          POWER_DISPLAY_COLOR,SU_FORMAT,USER_T0, time_stepping_scheme, &
@@ -193,6 +193,9 @@
 
   read(IIN,"(a80)") datlin
   read(IIN,*) save_binary_seismograms_single,save_binary_seismograms_double
+  
+  read(IIN,"(a80)") datlin
+  read(IIN,*) USE_TRICK_FOR_BETTER_PRESSURE
 
   read(IIN,"(a80)") datlin
   read(IIN,*) save_ASCII_kernels

--- a/src/specfem2D/specfem2D_par.f90
+++ b/src/specfem2D/specfem2D_par.f90
@@ -123,6 +123,7 @@ module specfem_par
 ! for seismograms
   double precision, dimension(:,:), allocatable :: sisux,sisuz,siscurl
   integer :: seismo_offset, seismo_current
+  logical :: USE_TRICK_FOR_BETTER_PRESSURE
 
 ! vector field in an element
   real(kind=CUSTOM_REAL), dimension(3,NGLLX,NGLLX) :: vector_field_element

--- a/src/specfem2D/write_seismograms.F90
+++ b/src/specfem2D/write_seismograms.F90
@@ -118,8 +118,23 @@
           dcurld=ZERO
 
           if(seismotype == 4) then
-
-            dxd = pressure_element(i,j)
+            if (USE_TRICK_FOR_BETTER_PRESSURE .and. (acoustic(ispec) .or. gravitoacoustic(ispec))) then 
+              ! use a trick to increase accuracy of pressure seismograms in fluid (acoustic) elements:
+              ! use the second derivative of the source for the source time function instead of the source itself,
+              ! and then record -potential_acoustic() as pressure seismograms instead of -potential_dot_dot_acoustic();
+              ! this is mathematically equivalent, but numerically significantly more accurate because in the explicit
+              ! Newmark time scheme acceleration is accurate at zeroth order while displacement is accurate at second order,
+              ! thus in fluid elements potential_dot_dot_acoustic() is accurate at zeroth order while potential_acoustic()
+              ! is accurate at second order and thus contains significantly less numerical noise.
+              ! compute pressure on the fluid/porous medium edge
+              if(gravitoacoustic(ispec)) then
+                dxd = - potential_gravitoacoustic(iglob)
+              else
+                dxd = - potential_acoustic(iglob)
+              endif
+            else
+              dxd = pressure_element(i,j) ! == potential_dot_dot_acoustic(iglob) (or potential_dot_dot_gravitoacoustic(iglob))
+            endif 
             dzd = ZERO
 
           else if((acoustic(ispec) .or. gravitoacoustic(ispec)) .and.  seismotype /= 6) then

--- a/utils/cubit2specfem2d/cubit2specfem2d.py
+++ b/utils/cubit2specfem2d/cubit2specfem2d.py
@@ -430,11 +430,9 @@ class mesh(object,mesh_tools):
             for ipml in range(0, 6): # iabs = 0,1,2,3,4,5 : for each pml layer (x_acoust, z_acoust, xz_acoust,x_elast, z_elast, xz_elast)
                if block == self.pml_boun[ipml]: # If the block considered correspond to the pml
                     faces_all[ipml]=cubit.get_block_faces(block) # Import all pml faces id as a Set
-                    print npml_elements," ",len(faces_all[ipml])
                     npml_elements=npml_elements+len(faces_all[ipml])
         pml_file.write('%10i\n' % npml_elements) # Print the number of faces on the pmls
         print 'Number of elements in all PMLs :',npml_elements
-        print faces_all
         for block,flag in zip(self.block_mat,self.block_flag): # For each 2D block
             quads=cubit.get_block_faces(block) # Import quads id
             for quad in quads: # For each quad
@@ -442,8 +440,8 @@ class mesh(object,mesh_tools):
                 for ipml in range(0, 6): # iabs = 0,1,2,3,4,5 : for each pml layer (x_acoust, z_acoust, xz_acoust,x_elast, z_elast, xz_elast)
                     if type(faces_all[ipml]) is not int: # ~ if there are elements in that pml
                         if quad in faces_all[ipml]: # If this quad is belong to that pml
-                            nodes=cubit.get_connectivity('face',quad) # Import the nodes describing the quad
-                            nodes=self.jac_check(list(nodes)) # Check the jacobian of the quad
+                          #  nodes=cubit.get_connectivity('face',quad) # Import the nodes describing the quad
+                          #  nodes=self.jac_check(list(nodes)) # Check the jacobian of the quad
                             pml_file.write(('%10i %10i\n') % (id_element,ipml%3+1)) # Write its id in the file next to its type
         # ipml%3+1 = 1 -> element belongs to a X CPML layer only (either in Xmin or in Xmax)
         # ipml%3+1 = 2 -> element belongs to a Z CPML layer only (either in Zmin or in Zmax)


### PR DESCRIPTION
use the second derivative of the source for the source time function instead of the source itself,
   and then record -potential_acoustic() as pressure seismograms instead of -potential_dot_dot_acoustic();
   this is mathematically equivalent, but numerically significantly more accurate because in the explicit
   Newmark time scheme acceleration is accurate at zeroth order while displacement is accurate at second order,
   thus in fluid elements potential_dot_dot_acoustic() is accurate at zeroth order while potential_acoustic()
   is accurate at second order and thus contains significantly less numerical noise.