### PR TITLE
Fix name of source file in configure.

### DIFF
--- a/configure
+++ b/configure
@@ -584,7 +584,7 @@ PACKAGE_STRING='Specfem 2D 6.2.0'
 PACKAGE_BUGREPORT='see the wiki'
 PACKAGE_URL=''
 
-ac_unique_file="README"
+ac_unique_file="README.md"
 # Factoring default headers for most tests.
 ac_includes_default="\
 #include <stdio.h>

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ dnl You must have recent versions of Autoconf and Automake installed.
 
 AC_PREREQ(2.61)
 AC_INIT([Specfem 2D], [6.2.0], [see the wiki], [Specfem2D])
-AC_CONFIG_SRCDIR([README])
+AC_CONFIG_SRCDIR([README.md])
 AC_CONFIG_HEADER([setup/config.h])
 AC_CONFIG_MACRO_DIR([m4])
 


### PR DESCRIPTION
README was recently renamed to README.md.

See #357.