### PR TITLE
Various updates for the smoothing routine

### DIFF
--- a/src/specfem2D/finalize_simulation.F90
+++ b/src/specfem2D/finalize_simulation.F90
@@ -98,6 +98,12 @@ enddo
           write(172) z_save
           close(172)
 
+          write(outputname,'(a,i6.6,a)') 'DATA/proc',myrank,'_jacobian.bin'
+          open(unit=172,file=outputname,status='unknown',form='unformatted')
+          write(172) jacobian
+          close(172)
+
+
   else
        stop 'Save Model not implemented for external and tomo'
 

--- a/src/specfem2D/prepare_assemble_MPI.F90
+++ b/src/specfem2D/prepare_assemble_MPI.F90
@@ -69,8 +69,7 @@
                                 inum_interfaces_acoustic, inum_interfaces_elastic, &
                                 inum_interfaces_poroelastic, &
                                 ninterface_acoustic, ninterface_elastic, ninterface_poroelastic, &
-                                mask_ispec_inner_outer,nibool_interfaces_ext_mesh, ibool_interfaces_ext_mesh_init,&
-                                max_interface_size
+                                mask_ispec_inner_outer,nibool_interfaces_ext_mesh, ibool_interfaces_ext_mesh_init
   implicit none
 
   include 'constants.h'

--- a/src/specfem2D/prepare_assemble_MPI.F90
+++ b/src/specfem2D/prepare_assemble_MPI.F90
@@ -70,7 +70,7 @@
                                 inum_interfaces_poroelastic, &
                                 ninterface_acoustic, ninterface_elastic, ninterface_poroelastic, &
                                 mask_ispec_inner_outer,nibool_interfaces_ext_mesh, ibool_interfaces_ext_mesh_init,&
-                                max_interface_size, outputname,myrank, SAVE_MODEL
+                                max_interface_size
   implicit none
 
   include 'constants.h'
@@ -217,20 +217,6 @@
       inum_interfaces_poroelastic(ninterface_poroelastic) = num_interface
     endif
   enddo
-
-if (SAVE_MODEL=='binary') then
-
-    write(outputname,'(a,i6.6,a)') 'DATA/proc',myrank,'_MPI_interfaces_info.bin'
-    open(unit=172,file=outputname,status='unknown',form='unformatted')
-    write(172) ninterface
-    write(172) my_nelmnts_neighbours
-    write(172) nibool_interfaces_ext_mesh
-    write(172) max_interface_size
-    write(172) ibool_interfaces_ext_mesh_init
-    close(172)
-
-endif
-
 
   end subroutine prepare_assemble_MPI
 

--- a/src/tomography/postprocess_sensitivity_kernels/smooth_cuda.cu
+++ b/src/tomography/postprocess_sensitivity_kernels/smooth_cuda.cu
@@ -1,0 +1,231 @@
+/*
+  !========================================================================
+  !
+  !                   S P E C F E M 2 D  Version 7 . 0
+  !                   --------------------------------
+  !
+  !     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+  !                        Princeton University, USA
+  !                and CNRS / University of Marseille, France
+  !                 (there are currently many more authors!)
+  ! (c) Princeton University and CNRS / University of Marseille, April 2014
+  !
+  ! This software is a computer program whose purpose is to solve
+  ! the two-dimensional viscoelastic anisotropic or poroelastic wave equation
+  ! using a spectral-element method (SEM).
+  !
+  ! This software is governed by the CeCILL license under French law and
+  ! abiding by the rules of distribution of free software. You can use,
+  ! modify and/or redistribute the software under the terms of the CeCILL
+  ! license as circulated by CEA, CNRS and Inria at the following URL
+  ! "http://www.cecill.info".
+  !
+  ! As a counterpart to the access to the source code and rights to copy,
+  ! modify and redistribute granted by the license, users are provided only
+  ! with a limited warranty and the software's author, the holder of the
+  ! economic rights, and the successive licensors have only limited
+  ! liability.
+  !
+  ! In this respect, the user's attention is drawn to the risks associated
+  ! with loading, using, modifying and/or developing or reproducing the
+  ! software by the user in light of its specific status of free software,
+  ! that may mean that it is complicated to manipulate, and that also
+  ! therefore means that it is reserved for developers and experienced
+  ! professionals having in-depth computer knowledge. Users are therefore
+  ! encouraged to load and test the software's suitability as regards their
+  ! requirements in conditions enabling the security of their systems and/or
+  ! data to be ensured and, more generally, to use and operate it in the
+  ! same conditions as regards security.
+  !
+  ! The full text of the license is available in file "LICENSE".
+  !
+  !========================================================================
+ 
+ */
+
+
+#include "smooth_cuda.h"
+#include "config.h"
+#include <stdio.h>
+// copies integer array from CPU host to GPU device
+void copy_todevice_int(void** d_array_addr_ptr,int* h_array,int size){
+   cudaMalloc((void**)d_array_addr_ptr,size*sizeof(int));
+   cudaMemcpy((int*) *d_array_addr_ptr,h_array,size*sizeof(int),cudaMemcpyHostToDevice);
+}
+
+void copy_todevice_realw(void** d_array_addr_ptr,realw* h_array,int size){
+   cudaMalloc((void**)d_array_addr_ptr,size*sizeof(realw));
+   cudaMemcpy((realw*) *d_array_addr_ptr,h_array,size*sizeof(realw),cudaMemcpyHostToDevice);
+}
+
+__global__ void process_smooth(realw_const_p xstore_me,realw_const_p zstore_me,realw_const_p xstore_other,realw_const_p zstore_other, realw_const_p data_other, const realw sigma_h2_inv, const realw sigma_v2_inv, const int iker, const int nspec_me, const int nspec_other, const realw v_criterion, const realw h_criterion, realw_const_p jacobian, realw_p sum_data_smooth, realw_p normalisation,realw_const_p wgll_sq){
+
+int ispec = blockIdx.x + gridDim.x*blockIdx.y;
+int igll = threadIdx.x;
+int gll_other;
+realw x_me, z_me, x_other, z_other, coef, normalisation_slice;
+realw dat;
+__shared__ int sh_test[NGLL2];
+__shared__ realw sh_x_other[NGLL2];
+__shared__ realw sh_z_other[NGLL2];
+__shared__ realw sh_jacobian[NGLL2];
+__shared__ realw sh_wgll_sq[NGLL2];
+__shared__ realw sh_data[NGLL2];
+
+int n_loop = nspec_other/NGLL2 + 1;
+x_me = xstore_me[NGLL2*ispec + igll ];
+z_me = zstore_me[NGLL2*ispec + igll ];
+sh_wgll_sq[igll]=wgll_sq[igll];
+__syncthreads();
+
+dat=0;
+normalisation_slice=0;
+//We test 32 spectral elements at a time
+for (int i=0;i<n_loop;i++)
+{
+if ( NGLL2*i + threadIdx.x < nspec_other){
+x_other = xstore_other[i*NGLL2*NGLL2 + threadIdx.x*NGLL2 ];
+z_other = zstore_other[i*NGLL2*NGLL2 + threadIdx.x*NGLL2 ];
+}
+sh_test[threadIdx.x] = ( NGLL2*i + threadIdx.x >= nspec_other || (x_me-x_other)*(x_me-x_other) > h_criterion || (z_me-z_other)*(z_me-z_other) > v_criterion ) ? 1 : 0 ;
+__syncthreads();
+
+//loop over each spectral element tested
+for (int k=0;k<NGLL2;k++)
+{
+if (sh_test[k]) continue ;
+
+//Load data from other slice to shared memory
+sh_x_other[igll] = xstore_other[i*NGLL2*NGLL2 + k*NGLL2 + igll ];
+sh_z_other[igll] = zstore_other[i*NGLL2*NGLL2 + k*NGLL2 + igll ];
+sh_data[igll] = data_other[i*NGLL2*NGLL2 + k*NGLL2 + igll ];
+sh_jacobian[igll] = jacobian[i*NGLL2*NGLL2 + k*NGLL2 + igll ];
+__syncthreads();
+
+for (int j=0;j<NGLL2;j++){
+
+gll_other = (igll + j) % NGLL2;
+
+x_other = sh_x_other[gll_other];
+z_other = sh_z_other[gll_other];
+coef = expf(- sigma_h2_inv*(x_me-x_other)*(x_me-x_other) - sigma_v2_inv*(z_me-z_other)*(z_me-z_other))*sh_jacobian[gll_other]*sh_wgll_sq[gll_other];
+normalisation_slice = normalisation_slice + coef;
+dat += sh_data[gll_other]*coef;
+} //loop on each gll_other
+} //loop on each spec_other tested
+} //loop on each serie of 32 spec_other
+
+sum_data_smooth[NGLL2*nspec_me*iker+NGLL2*ispec + igll] += dat;
+normalisation[NGLL2*ispec + igll] += normalisation_slice;
+}
+
+__global__ void normalize_data(realw_p data_smooth, realw_const_p normalisation,int nker, int nspec_me){
+int ispec = blockIdx.x + gridDim.x*blockIdx.y;
+realw norm = normalisation[NGLL2*ispec + threadIdx.x];
+for (int j=0;j<nker;j++) data_smooth[NGLL2*nspec_me*j + NGLL2*ispec + threadIdx.x] /= norm/nker;
+}
+
+extern "C"
+void FC_FUNC_(prepare_gpu,
+              PREPARE_GPU)(long * Container,
+                          realw * xstore_me,
+                          realw * zstore_me,
+                          realw * sigma_h2_inv,
+                          realw * sigma_v2_inv,
+                          realw * h_criterion,
+                          realw * v_criterion,
+                          int * nspec_me,
+                          int * nker,
+                          realw * wgll_sq){
+
+  Smooth_data* sp = (Smooth_data*)malloc( sizeof(Smooth_data) );
+  *Container = (long)sp;
+
+  copy_todevice_realw((void**)&sp->x_me,xstore_me, NGLL2*(*nspec_me));
+  copy_todevice_realw((void**)&sp->z_me,zstore_me, NGLL2*(*nspec_me));
+  copy_todevice_realw((void**)&sp->wgll_sq,wgll_sq, NGLL2);
+
+  sp->sigma_h2_inv= *sigma_h2_inv;
+  sp->sigma_v2_inv= *sigma_v2_inv;
+  sp->h_criterion = *h_criterion;
+  sp->v_criterion = *v_criterion;
+  sp->nspec_me =  *nspec_me;
+  sp->nker = *nker;
+
+  print_CUDA_error_if_any(cudaMalloc((void**)&sp->data_smooth,NGLL2*(*nspec_me)*(*nker)*sizeof(realw)),2000);
+  print_CUDA_error_if_any(cudaMemset(sp->data_smooth,0,NGLL2*(*nspec_me)*(*nker)*sizeof(realw)),2001);
+
+  print_CUDA_error_if_any(cudaMalloc((void**)&sp->normalisation,NGLL2*(*nspec_me)*sizeof(realw)),2002);
+  print_CUDA_error_if_any(cudaMemset(sp->normalisation,0,NGLL2*(*nspec_me)*sizeof(realw)),2003);
+}
+
+extern "C"
+void FC_FUNC_(compute_smooth,
+              COMPUTE_SMOOTH)(long * smooth_pointer,
+                              realw * jacobian,
+                              realw * xstore_other,
+                              realw * zstore_other,
+                              realw * data_other,
+                              const int * nspec_other){
+realw * x_other;
+realw * z_other;
+realw * d_data_other;
+realw * d_jacobian;
+
+Smooth_data * sp = (Smooth_data*)*smooth_pointer;
+
+copy_todevice_realw((void**)&x_other,xstore_other,NGLL2*(*nspec_other));
+copy_todevice_realw((void**)&z_other,zstore_other,NGLL2*(*nspec_other));
+copy_todevice_realw((void**)&d_jacobian,jacobian,NGLL2*(*nspec_other));
+
+dim3 grid(sp->nspec_me,1);
+dim3 threads(NGLL2,1,1);
+
+for (int i=0;i<sp->nker;i++)
+{
+copy_todevice_realw((void**)&d_data_other,&data_other[NGLL2*(*nspec_other)*i],NGLL2*(*nspec_other));
+process_smooth<<<grid,threads>>>(sp->x_me,
+                                 sp->z_me,
+                                 x_other,
+                                 z_other,
+                                 d_data_other,
+                                 sp->sigma_h2_inv,
+                                 sp->sigma_v2_inv,
+                                 i,
+                                 sp->nspec_me,
+                                 *nspec_other,
+                                 sp->v_criterion,
+                                 sp->h_criterion,
+                                 d_jacobian,
+                                 sp->data_smooth,
+                                 sp->normalisation,
+                                 sp->wgll_sq);
+cudaFree(d_data_other);
+}
+
+synchronize_cuda();
+cudaFree(x_other);
+cudaFree(z_other);
+cudaFree(d_jacobian);
+}
+
+extern "C"
+void FC_FUNC_(get_smooth,
+              GET_SMOOTH)(long * smooth_pointer,realw * data_smooth){
+
+Smooth_data * sp = (Smooth_data*)*smooth_pointer;
+dim3 grid(sp->nspec_me,1);
+dim3 threads(NGLL2,1,1);
+
+normalize_data<<<grid,threads>>>(sp->data_smooth,sp->normalisation,sp->nker,sp->nspec_me);
+print_CUDA_error_if_any(cudaMemcpy(data_smooth, sp->data_smooth,
+                                     NGLL2*sp->nspec_me*sizeof(int)*sp->nker, cudaMemcpyDeviceToHost),98012);
+
+cudaFree(sp->x_me);
+cudaFree(sp->z_me);
+cudaFree(sp->data_smooth);
+cudaFree(sp->wgll_sq);
+cudaFree(sp->normalisation);
+free(sp);
+}
+

--- a/src/tomography/postprocess_sensitivity_kernels/smooth_cuda.h
+++ b/src/tomography/postprocess_sensitivity_kernels/smooth_cuda.h
@@ -1,0 +1,70 @@
+/*
+ !========================================================================
+ !
+ !                   S P E C F E M 2 D  Version 7 . 0
+ !                   --------------------------------
+ !
+ !     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+ !                        Princeton University, USA
+ !                and CNRS / University of Marseille, France
+ !                 (there are currently many more authors!)
+ ! (c) Princeton University and CNRS / University of Marseille, April 2014
+ !
+ ! This software is a computer program whose purpose is to solve
+ ! the two-dimensional viscoelastic anisotropic or poroelastic wave equation
+ ! using a spectral-element method (SEM).
+ !
+ ! This software is governed by the CeCILL license under French law and
+ ! abiding by the rules of distribution of free software. You can use,
+ ! modify and/or redistribute the software under the terms of the CeCILL
+ ! license as circulated by CEA, CNRS and Inria at the following URL
+ ! "http://www.cecill.info".
+ !
+ ! As a counterpart to the access to the source code and rights to copy,
+ ! modify and redistribute granted by the license, users are provided only
+ ! with a limited warranty and the software's author, the holder of the
+ ! economic rights, and the successive licensors have only limited
+ ! liability.
+ !
+ ! In this respect, the user's attention is drawn to the risks associated
+ ! with loading, using, modifying and/or developing or reproducing the
+ ! software by the user in light of its specific status of free software,
+ ! that may mean that it is complicated to manipulate, and that also
+ ! therefore means that it is reserved for developers and experienced
+ ! professionals having in-depth computer knowledge. Users are therefore
+ ! encouraged to load and test the software's suitability as regards their
+ ! requirements in conditions enabling the security of their systems and/or
+ ! data to be ensured and, more generally, to use and operate it in the
+ ! same conditions as regards security.
+ !
+ ! The full text of the license is available in file "LICENSE".
+ !
+ !========================================================================
+*/
+
+// Gauss-Lobatto-Legendre
+#define NGLL 5
+#define NGLLX 5
+#define NGLL2 25
+
+typedef float realw;
+typedef const realw* __restrict__ realw_const_p;
+typedef realw* __restrict__ realw_p;
+
+
+void print_CUDA_error_if_any(cudaError_t err, int num);
+void synchronize_cuda();
+typedef struct Smooth_data_ {
+realw * x_me;
+realw * z_me;
+realw * data_smooth;
+realw * normalisation;
+realw * wgll_sq;
+realw sigma_h2_inv;
+realw sigma_v2_inv;
+realw h_criterion;
+realw v_criterion;
+int nspec_me;
+int nker;
+} Smooth_data;
+

--- a/src/tomography/postprocess_sensitivity_kernels/smooth_sem.F90
+++ b/src/tomography/postprocess_sensitivity_kernels/smooth_sem.F90
@@ -1,0 +1,549 @@
+
+!========================================================================
+!
+!                   S P E C F E M 2 D  Version 7 . 0
+!                   --------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This software is a computer program whose purpose is to solve
+! the two-dimensional viscoelastic anisotropic or poroelastic wave equation
+! using a spectral-element method (SEM).
+!
+! This software is governed by the CeCILL license under French law and
+! abiding by the rules of distribution of free software. You can use,
+! modify and/or redistribute the software under the terms of the CeCILL
+! license as circulated by CEA, CNRS and Inria at the following URL
+! "http://www.cecill.info".
+!
+! As a counterpart to the access to the source code and rights to copy,
+! modify and redistribute granted by the license, users are provided only
+! with a limited warranty and the software's author, the holder of the
+! economic rights, and the successive licensors have only limited
+! liability.
+!
+! In this respect, the user's attention is drawn to the risks associated
+! with loading, using, modifying and/or developing or reproducing the
+! software by the user in light of its specific status of free software,
+! that may mean that it is complicated to manipulate, and that also
+! therefore means that it is reserved for developers and experienced
+! professionals having in-depth computer knowledge. Users are therefore
+! encouraged to load and test the software's suitability as regards their
+! requirements in conditions enabling the security of their systems and/or
+! data to be ensured and, more generally, to use and operate it in the
+! same conditions as regards security.
+!
+! The full text of the license is available in file "LICENSE".
+!
+!========================================================================
+
+! XSMOOTH_SEM
+!
+! USAGE
+!   mpirun -np NPROC bin/xsmooth_sem SIGMA_H SIGMA_V KERNEL_NAME INPUT_DIR OUPUT_DIR GPU_MODE
+!
+!
+! COMMAND LINE ARGUMENTS
+!   SIGMA_H                - horizontal smoothing radius
+!   SIGMA_V                - vertical smoothing radius
+!   KERNEL_NAME            - kernel name, e.g. alpha_kernel
+!   INPUT_DIR              - directory from which kernels are read
+!   OUTPUT_DIR             - directory to which smoothed kernels are written
+!   GPU_MODE               - use GPUs to process smoothing (logical T F) 
+
+! DESCRIPTION
+!   Smooths kernels by convolution with a Gaussian. Writes the resulting
+!   smoothed kernels to OUTPUT_DIR.
+!
+!   Files written to OUTPUT_DIR have the suffix 'smooth' appended,
+!   e.g. proc***alpha_kernel.bin becomes proc***alpha_kernel_smooth.bin
+!
+!   This program's primary use case is to smooth kernels. It can be used though on
+!   any scalar field of dimension (NGLLX,NGLLZ,NSPEC).
+!
+!   This is a parallel program -- it must be invoked with mpirun or other
+!   appropriate utility.  Operations are performed in embarassingly-parallel
+!   fashion.
+
+
+program smooth_sem
+
+
+
+#ifdef USE_MPI
+  use mpi
+#endif
+
+  use postprocess_par
+
+  implicit none
+
+#ifdef USE_MPI
+  include "precision.h"
+#endif
+
+  integer, parameter :: NARGS = 6
+
+  ! data must be of dimension: (NGLLX,NGLLZ,NSPEC_AB)
+  real(kind=CUSTOM_REAL), dimension(:,:,:),allocatable :: dat
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:),allocatable :: dat_store,dat_smooth
+  integer :: NGLOB_me, myrank,nproc, nspec_me, nspec_other, ncuda_devices
+  integer(kind=8) :: Container
+
+  integer :: i,j,ier,ispec2,ispec, iker, iglob
+  integer :: iproc
+
+  character(len=MAX_STRING_LEN) :: arg(6)
+  character(len=MAX_STRING_LEN) :: input_dir, output_dir
+  character(len=MAX_STRING_LEN) :: prname
+
+  logical :: GPU_MODE
+
+  character(len=MAX_STRING_LEN) :: kernel_names(MAX_KERNEL_NAMES)
+  character(len=MAX_STRING_LEN) :: kernel_names_comma_delimited
+  integer :: nker
+
+  ! smoothing parameters
+  character(len=MAX_STRING_LEN*2) :: ks_file
+
+  real(kind=CUSTOM_REAL) :: sigma_h, sigma_h2_inv, sigma_h3_sq, sigma_v,sigma_v2_inv, sigma_v3_sq
+  real(kind=CUSTOM_REAL) :: norm_h, norm_v
+  real(kind=CUSTOM_REAL), dimension(:),allocatable :: norm, max_old,max_new, min_old, min_new
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLZ) :: exp_val, factor, wgll_sq
+  real(kind=CUSTOM_REAL), dimension(NGLLX) :: wxgll
+  double precision, dimension(NGLLX) :: xigll
+  double precision, parameter :: alphaGLL = 0.d0, betaGLL = 0.d0
+  integer, dimension(:,:,:),allocatable :: ibool_me
+  integer, dimension(:),allocatable :: imask
+  real(kind=CUSTOM_REAL), dimension(:,:),allocatable :: tk
+  real(kind=CUSTOM_REAL), dimension(:),allocatable :: bk
+  real(kind=CUSTOM_REAL), dimension(:,:,:),allocatable :: xstore_me, zstore_me,xstore_other, zstore_other, jacobian
+
+
+  real(kind=CUSTOM_REAL) :: dist_h,dist_v
+  real(kind=CUSTOM_REAL) :: element_size
+  real(kind=CUSTOM_REAL), PARAMETER :: PI = 3.1415927
+  real t1,t2
+#ifdef USE_MPI
+  call MPI_INIT(ier)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD,nproc,ier)
+  call MPI_COMM_RANK(MPI_COMM_WORLD,myrank,ier)
+#else
+nproc = 1
+myrank = 0
+#endif
+
+  if (myrank == 0) print *,"Running XSMOOTH_SEM on",NPROC,"processors"
+  call cpu_time(t1)
+
+  ! parse command line arguments
+  if (command_argument_count() /= NARGS) then
+    if (myrank == 0) then
+        print *, 'USAGE:  mpirun -np NPROC bin/xsmooth_sem SIGMA_H SIGMA_V KERNEL_NAME INPUT_DIR OUPUT_DIR GPU_MODE'
+      stop ' Please check command line arguments'
+    endif
+  endif
+
+#ifdef USE_MPI
+  call MPI_BARRIER(MPI_COMM_WORLD,ier)
+#endif
+
+  do i = 1, NARGS
+    call get_command_argument(i,arg(i), status=ier)
+  enddo
+
+  read(arg(1),*) sigma_h
+  read(arg(2),*) sigma_v
+  kernel_names_comma_delimited = arg(3)
+  input_dir= arg(4)
+  output_dir = arg(5)
+
+  call parse_kernel_names(kernel_names_comma_delimited,kernel_names,nker)
+  allocate(norm(nker),max_new(nker),max_old(nker),min_new(nker),min_old(nker))
+
+ if(GPU_MODE) call initialize_cuda_device(myrank,ncuda_devices)
+
+  call zwgljd(xigll,wxgll,NGLLX,alphaGLL,betaGLL)
+  !We assume NGLLX=NGLLZ	
+  do j=1,NGLLZ
+    do i=1,NGLLX
+      wgll_sq(i,j) = wxgll(i)*wxgll(j)
+    enddo
+  enddo
+
+  ! check smoothing radii
+  sigma_h2_inv = ( 1.0 / (2.0 * (sigma_h ** 2)) ) ! factor two for gaussian distribution with standard variance sigma
+  sigma_v2_inv = ( 1.0 / (2.0 * (sigma_v ** 2)) )
+
+  if ( (1.0 / sigma_h2_inv) < 1.e-18) stop 'Error sigma_h2 zero, must non-zero'
+  if ( (1.0 / sigma_v2_inv) < 1.e-18) stop 'Error sigma_v2 zero, must non-zero'
+
+  ! adds margin to search radius
+  element_size = max(sigma_h,sigma_v) * 0.5
+
+  ! search radius
+  sigma_h3_sq = (3.0  * sigma_h + element_size)**2
+  sigma_v3_sq = (3.0  * sigma_v + element_size)**2
+
+  ! theoretic normal value
+  ! (see integral over -inf to +inf of exp[- x*x/(2*sigma) ] = sigma * sqrt(2*pi) )
+  ! note: smoothing is using a gaussian (ellipsoid for sigma_h /= sigma_v),
+  norm_h = 2.0*PI*sigma_h**2
+  norm_v = sqrt(2.0*PI) * sigma_v
+
+  ! user output
+  if (myrank == 0) then
+    print *,"command line arguments:"
+    print *,"  smoothing sigma_h , sigma_v                : ",sigma_h,sigma_v
+    ! scalelength: approximately S ~ sigma * sqrt(8.0) for a gaussian smoothing
+    print *,"  smoothing scalelengths horizontal, vertical: ",sigma_h*sqrt(8.0),sigma_v*sqrt(8.0)
+    print *,"  input dir : ",trim(input_dir)
+    print *,"  output dir: ",trim(output_dir)
+    print *
+  endif
+
+
+  write(prname,'(a,i6.6,a)') trim(input_dir)//'/proc',myrank,'_NSPEC_ibool.bin'
+  open(IIN,file=trim(prname),status='old',action='read',form='unformatted',iostat=ier)
+  if (ier /= 0) then
+      print *,'Error: could not open database file: ',trim(prname)
+      stop 'Error opening _NSPEC_IBOOL file'
+  endif
+  read(IIN) nspec_me
+  allocate(ibool_me(NGLLX,NGLLZ,nspec_me))
+  read(IIN) ibool_me
+  close(IIN)
+  nglob_me = maxval(ibool_me(:,:,:))
+  allocate(xstore_me(NGLLX,NGLLZ,NSPEC_me),zstore_me(NGLLX,NGLLZ,NSPEC_me),imask(nglob_me),stat=ier)
+
+    write(prname, '(a,i6.6,a)') trim(input_dir)//'/proc',myrank,'_x.bin'
+    ! gets the coordinate x of the points located in my slice
+    open(unit=IIN,file=trim(prname),status='old',action='read',form='unformatted',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error: could not open database file: ',trim(prname)
+      stop 'Error reading neighbors external mesh file'
+    endif
+    ! global point arrays
+    read(IIN) xstore_me
+    close(IIN)
+
+    write(prname, '(a,i6.6,a)') trim(input_dir)//'/proc',myrank,'_z.bin'
+    ! gets the coordinate z of the points located in my slice
+    open(unit=IIN,file=trim(prname),status='old',action='read',form='unformatted',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error: could not open database file: ',trim(prname)
+      stop 'Error reading neighbors external mesh file'
+    endif
+    ! global point arrays
+    read(IIN) zstore_me
+    close(IIN)
+
+
+
+  ! synchronizes
+#ifdef USE_MPI
+  call MPI_BARRIER(MPI_COMM_WORLD,ier)
+#endif
+
+if (GPU_MODE) then
+
+  call prepare_GPU(Container,xstore_me,zstore_me,sigma_h2_inv,sigma_v2_inv,sigma_h3_sq,sigma_v3_sq,nspec_me,nker,wgll_sq)
+
+endif
+
+  ! synchronizes
+#ifdef USE_MPI
+  call MPI_BARRIER(MPI_COMM_WORLD,ier)
+#endif
+
+
+! loops over slices
+! each process reads all the other slices and gaussian filters the values
+  allocate(tk(nglob_me,nker), bk(nglob_me),stat=ier)
+  if (ier /= 0) stop 'Error allocating array tk and bk'
+
+  tk = 0.0_CUSTOM_REAL
+  bk = 0.0_CUSTOM_REAL
+
+  do iproc = 0,NPROC-1
+    ! slice database file
+    write(prname,'(a,i6.6,a)') trim(input_dir)//'/proc',iproc,'_NSPEC_ibool.bin'
+    open(IIN,file=trim(prname),status='old',action='read',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'Error opening ibool file'
+    read(IIN) nspec_other
+    close(IIN)
+    allocate(xstore_other(NGLLX,NGLLZ,NSPEC_other),zstore_other(NGLLX,NGLLZ,NSPEC_other),&
+             jacobian(NGLLX,NGLLZ,NSPEC_other),stat=ier)
+    if (ier /= 0) stop 'Error allocating array xstore_other etc.'
+
+     write(prname, '(a,i6.6,a)') trim(input_dir)//'/proc',iproc,'_x.bin'
+    ! gets the coordinate x of the points located in the other slice
+    open(unit=IIN,file=trim(prname),status='old',action='read',form='unformatted',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error: could not open database file: ',trim(prname)
+      stop 'Error reading x coordinate'
+    endif
+    ! global point arrays
+    read(IIN) xstore_other
+    close(IIN)
+
+    write(prname, '(a,i6.6,a)') trim(input_dir)//'/proc',iproc,'_z.bin'
+    ! gets the coordinate z of the points located in the other slice
+    open(unit=IIN,file=trim(prname),status='old',action='read',form='unformatted',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error: could not open database file: ',trim(prname)
+      stop 'Error reading z coordinate'
+    endif
+    ! global point arrays
+    read(IIN) zstore_other
+    close(IIN)
+
+    write(prname, '(a,i6.6,a)') trim(input_dir)//'/proc',iproc,'_jacobian.bin'
+    ! gets the jacobian of the points located in the other slice
+    open(unit=IIN,file=trim(prname),status='old',action='read',form='unformatted',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error: could not open database file: ',trim(prname)
+      stop 'Error reading jacobian'
+    endif
+    ! global point arrays
+    read(IIN) jacobian
+    close(IIN)
+
+    allocate(dat(NGLLX,NGLLZ,NSPEC_other),dat_store(NGLLX,NGLLZ,NSPEC_other,nker),stat=ier)
+    if (ier /= 0) stop 'Error allocating dat array'
+
+  do iker= 1, nker
+    ! data file
+    write(prname,'(a,i6.6,a)') trim(input_dir)//'/proc',iproc,'_'//trim(kernel_names(iker))//'.bin'
+
+    open(unit = IIN,file = trim(prname),status='old',action='read',form ='unformatted',iostat=ier)
+    if (ier /= 0) then
+      print *,'Error opening data file: ',trim(prname)
+      stop 'Error opening data file'
+    endif
+    read(IIN) dat
+    close(IIN)
+
+  dat_store(:,:,:,iker) = dat(:,:,:)
+
+    if (iproc == myrank) then
+      max_old(iker) = maxval(abs(dat(:,:,:)))
+      min_old(iker) = minval(abs(dat(:,:,:)))
+    endif
+
+  enddo
+imask=-1
+
+if (GPU_MODE) then
+  call compute_smooth(Container,jacobian,xstore_other,zstore_other,dat_store,nspec_other)
+else
+    ! loop over elements to be smoothed in the current slice
+    do ispec = 1, nspec_me
+      ! --- only double loop over the elements in the search radius ---
+      do ispec2 = 1, nspec_other
+
+        ! calculates horizontal and vertical distance between two element centers
+        call get_distance_square_vec(dist_h,dist_v,xstore_me(1,1,ispec),zstore_me(1,1,ispec),&
+                          xstore_other(1,1,ispec2),zstore_other(1,1,ispec2))
+
+        ! checks distance between centers of elements
+   !     if (dist_h > 2*sigma_h3_sq .or. dist_v > 2*sigma_v3_sq) cycle
+    
+
+
+        factor(:,:) = jacobian(:,:,ispec2) * wgll_sq(:,:)
+
+    ! loop over GLL points of the elements in current slice (ispec)
+        do j = 1, NGLLZ
+            do i = 1, NGLLX
+              iglob = ibool_me(i,j,ispec)
+              if (imask(iglob)==1) cycle
+
+              ! calculate weights based on gaussian smoothing
+              exp_val = 0.0_CUSTOM_REAL
+
+              call smoothing_weights_vec(xstore_me(i,j,ispec),zstore_me(i,j,ispec),sigma_h2_inv,sigma_v2_inv,exp_val,&
+                      xstore_other(:,:,ispec2),zstore_other(:,:,ispec2))
+              
+              exp_val(:,:) = exp_val(:,:) * factor(:,:)
+
+              ! adds contribution of element ispec2 to smoothed kernel values
+              do iker=1, nker
+              tk(iglob,iker) = tk(iglob,iker) + sum(exp_val(:,:) * dat_store(:,:,ispec2,iker))
+              enddo
+              ! normalization, integrated values of gaussian smoothing function
+              bk(iglob) = bk(iglob) + sum(exp_val(:,:))
+
+            enddo
+        enddo
+      enddo ! ispec2
+
+        do j = 1, NGLLZ
+            do i = 1, NGLLX
+              imask(ibool_me(i,j,ispec)) = 1
+            enddo
+        enddo
+
+    enddo ! ispec
+
+endif !GPU_MODE
+
+
+    ! frees arrays
+    deallocate(dat,dat_store,xstore_other,zstore_other,jacobian)
+
+  enddo ! iproc
+
+  ! normalizes/scaling factor
+  if (myrank == 0) print *
+  if (myrank == 0) print *, 'Scaling values: min/max = ',minval(bk),maxval(bk)
+
+  allocate(dat_smooth(NGLLX,NGLLZ,NSPEC_me,nker),stat=ier)
+  if (ier /= 0) stop 'Error allocating array dat_smooth'
+
+  dat_smooth(:,:,:,:) = 0.0_CUSTOM_REAL
+ if (GPU_MODE) then
+    call get_smooth(Container,dat_smooth)
+  else
+
+  do ispec = 1, nspec_me
+      do j = 1, NGLLZ
+        do i = 1, NGLLX
+ !         if (abs(bk(i,j,ispec)) < 1.e-18) then
+ !           print *, 'Problem norm here --- ', ispec, i, j, bk(i,j,ispec)
+  !        endif
+              iglob = ibool_me(i,j,ispec)
+          ! normalizes smoothed kernel values by integral value of gaussian weighting
+          dat_smooth(i,j,ispec,:) = tk(iglob,:) / bk(iglob)
+        enddo
+      enddo
+  enddo !  ispec
+
+ endif
+
+  deallocate(tk,bk)
+
+do iker= 1, nker
+
+  max_new(iker) = maxval(abs(dat_smooth(:,:,:,iker)))
+  min_new(iker) = minval(abs(dat_smooth(:,:,:,iker)))
+  ! file output
+  ! smoothed kernel file name
+  write(ks_file,'(a,i6.6,a)') trim(output_dir)//'/proc',myrank,'_'//trim(kernel_names(iker))//'_smooth.bin'
+
+  open(IOUT,file=trim(ks_file),status='unknown',form='unformatted',iostat=ier)
+  if (ier /= 0) stop 'Error opening smoothed kernel file'
+  write(IOUT) dat_smooth(:,:,:,iker)
+  close(IOUT)
+  if (myrank == 0) print *,'written: ',trim(ks_file)
+enddo
+  ! frees memory
+  deallocate(dat_smooth)
+
+#ifdef USE_MPI
+  ! synchronizes
+  if (NPROC>1) then
+  call MPI_BARRIER(MPI_COMM_WORLD,ier)
+
+    ! the maximum value for the smoothed kernel
+    norm(:) = max_old(:)
+
+
+    call MPI_REDUCE(norm,max_old,nker,CUSTOM_MPI_TYPE,MPI_MAX,0,MPI_COMM_WORLD,ier)
+
+    norm(:) = max_new(:)
+
+    call MPI_REDUCE(norm,max_new,nker,CUSTOM_MPI_TYPE,MPI_MAX,0,MPI_COMM_WORLD,ier)
+    norm(:) = min_old(:)
+
+
+    call MPI_REDUCE(norm,min_old,nker,CUSTOM_MPI_TYPE,MPI_MIN,0,MPI_COMM_WORLD,ier)
+
+    norm(:) = min_new(:)
+
+    call MPI_REDUCE(norm,min_new,nker,CUSTOM_MPI_TYPE,MPI_MIN,0,MPI_COMM_WORLD,ier)
+
+  endif
+#endif
+
+  do iker= 1, nker
+    if (myrank == 0) then
+      print *
+      print *,' Min / Max data value before smoothing = ', min_old(iker), max_old(iker), 'for ', trim(kernel_names(iker))
+      print *,' Min / Max data value after smoothing  = ', min_new(iker), max_new(iker), 'for ', trim(kernel_names(iker))
+
+    endif
+  enddo
+   call cpu_time(t2)
+
+  if (GPU_Mode) then
+    print*,'Computation time with GPU:',t2-t1
+  else
+    print*,'Computation time with CPU:',t2-t1
+  endif
+
+   if (myrank == 0) close(IIN)
+
+#ifdef USE_MPI
+  ! stop all the processes and exit
+  call MPI_FINALIZE(ier)
+#endif
+
+end program smooth_sem
+
+!
+! -----------------------------------------------------------------------------
+!
+  subroutine smoothing_weights_vec(x0,z0,sigma_h2_inv,sigma_v2_inv,exp_val,xx_elem,zz_elem)
+
+  use constants
+  implicit none
+
+  real(kind=CUSTOM_REAL),dimension(NGLLX,NGLLZ),intent(out) :: exp_val
+  real(kind=CUSTOM_REAL),dimension(NGLLX,NGLLZ),intent(in) :: xx_elem, zz_elem
+  real(kind=CUSTOM_REAL),intent(in) :: x0,z0,sigma_h2_inv,sigma_v2_inv
+
+
+  ! local parameters
+  integer :: ii,jj
+  real(kind=CUSTOM_REAL) :: dist_h,dist_v
+
+ 
+  do jj = 1, NGLLZ
+    do ii = 1, NGLLX
+      ! gets vertical and horizontal distance
+      call get_distance_square_vec(dist_h,dist_v,x0,z0,xx_elem(ii,jj),zz_elem(ii,jj))
+       ! gaussian function
+      exp_val(ii,jj) = exp(- sigma_h2_inv*dist_h - sigma_v2_inv*dist_v)
+    enddo
+  enddo
+
+  end subroutine smoothing_weights_vec
+
+
+!
+! -----------------------------------------------------------------------------
+!
+
+  subroutine get_distance_square_vec(dist_h,dist_v,x0,z0,x1,z1)
+
+! returns square lengths as distances in radial and horizontal direction
+! only for flat earth with z in vertical direction
+
+  use constants
+  implicit none
+
+  real(kind=CUSTOM_REAL),intent(out) :: dist_h,dist_v
+  real(kind=CUSTOM_REAL),intent(in) :: x0,z0,x1,z1
+
+  ! vertical distance
+  dist_v =  (z0-z1)**2
+
+  ! horizontal distance
+  dist_h =  (x0-x1)**2
+
+  end subroutine get_distance_square_vec

--- a/src/tomography/postprocess_sensitivity_kernels/smooth_sem_cuda_stubs.c
+++ b/src/tomography/postprocess_sensitivity_kernels/smooth_sem_cuda_stubs.c
@@ -1,0 +1,79 @@
+/*
+  !========================================================================
+  !
+  !                   S P E C F E M 2 D  Version 7 . 0
+  !                   --------------------------------
+  !
+  !     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+  !                        Princeton University, USA
+  !                and CNRS / University of Marseille, France
+  !                 (there are currently many more authors!)
+  ! (c) Princeton University and CNRS / University of Marseille, April 2014
+  !
+  ! This software is a computer program whose purpose is to solve
+  ! the two-dimensional viscoelastic anisotropic or poroelastic wave equation
+  ! using a spectral-element method (SEM).
+  !
+  ! This software is governed by the CeCILL license under French law and
+  ! abiding by the rules of distribution of free software. You can use,
+  ! modify and/or redistribute the software under the terms of the CeCILL
+  ! license as circulated by CEA, CNRS and Inria at the following URL
+  ! "http://www.cecill.info".
+  !
+  ! As a counterpart to the access to the source code and rights to copy,
+  ! modify and redistribute granted by the license, users are provided only
+  ! with a limited warranty and the software's author, the holder of the
+  ! economic rights, and the successive licensors have only limited
+  ! liability.
+  !
+  ! In this respect, the user's attention is drawn to the risks associated
+  ! with loading, using, modifying and/or developing or reproducing the
+  ! software by the user in light of its specific status of free software,
+  ! that may mean that it is complicated to manipulate, and that also
+  ! therefore means that it is reserved for developers and experienced
+  ! professionals having in-depth computer knowledge. Users are therefore
+  ! encouraged to load and test the software's suitability as regards their
+  ! requirements in conditions enabling the security of their systems and/or
+  ! data to be ensured and, more generally, to use and operate it in the
+  ! same conditions as regards security.
+  !
+  ! The full text of the license is available in file "LICENSE".
+  !
+  !========================================================================
+ 
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "config.h"
+
+typedef float realw;
+
+void FC_FUNC_(initialize_cuda_device,
+              INITIALIZE_CUDA_DEVICE)(int* myrank_f,int* ncuda_devices){}
+
+
+void FC_FUNC_(prepare_gpu,
+              PREPARE_GPU)(long * Container,
+                          realw * xstore_me,
+                          realw * zstore_me,
+                          realw sigma_h2_inv,
+                          realw sigma_v2_inv,
+                          realw h_criterion,
+                          realw v_criterion,
+                          int nspec_me,
+                          int nker,
+                          realw gll){}
+
+void FC_FUNC_(compute_smooth,
+              COMPUTE_SMOOTH)(long * smooth_pointer,
+                              realw * jacobian,
+                              realw * xstore_other,
+                              realw * zstore_other,
+                              realw * data_other,
+                              const int * nspec_other){}
+
+
+void FC_FUNC_(get_smooth,
+              GET_SMOOTH)(long * smooth_pointer,realw * data_smooth){}


### PR DESCRIPTION
Modifications in the smoothing routine : 
-The integral convolution is not approximated anymore : we use a surface integral following the quadrature rule for spectral elements.
-CPU code optimized.
-Added CUDA support, a new flag (GPU_MODE) must be provided to the routine.