### PR TITLE
source_type check changed to allow Rayleigh/plane P,S again

### DIFF
--- a/src/meshfem2D/read_source_file.f90
+++ b/src/meshfem2D/read_source_file.f90
@@ -184,7 +184,8 @@
     write(IMAIN,*)
 
     ! source type
-    write(IMAIN,*) '  Source type (1=force, 2=moment tensor): ',source_type(i_source)
+    write(IMAIN,*) '  Source type (1=force, 2=moment tensor, 3=Rayleigh wave, 4=plane incident P, &
+                   &5=plane incident S): ',source_type(i_source)
     select case (source_type(i_source))
     case (1)
       ! force
@@ -197,9 +198,20 @@
       write(IMAIN,*) '  Mxx of the source = ',Mxx(i_source)
       write(IMAIN,*) '  Mzz of the source = ',Mzz(i_source)
       write(IMAIN,*) '  Mxz of the source = ',Mxz(i_source)
+    case (3)
+      ! Rayleigh wave
+      write(IMAIN,*) '  Rayleigh wave source:'  
+    case (4)
+      ! plane P wave without converted/refracted phases
+      write(IMAIN,*) '  Plane P-wave source without converted/refracted phases:'
+      write(IMAIN,*) '  Angle of the incident wave (deg) = ',anglesource(i_source)
+    case (5)
+      ! plane S wave without converted/refracted phases
+      write(IMAIN,*) '  Plane S-wave source without converted/refracted phases:'
+      write(IMAIN,*) '  Angle of the incident wave (deg) = ',anglesource(i_source)
     case default
       ! not supported yet
-      stop 'Error invalid source type! must be 1 or 2, exiting...'
+      stop 'Error invalid source type! must be 1, 2, 3, 4 or 5, exiting...'
     end select
     write(IMAIN,*)
 


### PR DESCRIPTION
Rayleigh wave and plane P- or S- waves without reflections/conversions from the free surfaces could not be chosen as sources any more, because the check returned false for any source_type other than 1 and 2 (Rayleigh=3, pure P plane wave= 4, pure S plane wave =5; and these are still supported without changes in the rest of the code as far as I can see).