### PR TITLE
Seismograms and adjoint sources routines now use smaller arrays

### DIFF
--- a/src/cuda/compute_add_sources_acoustic_cuda.cu
+++ b/src/cuda/compute_add_sources_acoustic_cuda.cu
@@ -195,9 +195,8 @@ __global__ void add_sources_ac_SIM_TYPE_2_OR_3_kernel(realw* potential_dot_dot_a
                                                       realw* gammar_store,
                                                       int* d_ibool,
                                                       int* ispec_is_acoustic,
-                                                      int* ispec_selected_rec,
+                                                      int* ispec_selected_rec_loc,
                                                       int it,
-                                                      int* pre_computed_irec,
                                                       int nadj_rec_local,
                                                       realw* kappastore,
                                                       int NSTEP ) {
@@ -207,9 +206,7 @@ __global__ void add_sources_ac_SIM_TYPE_2_OR_3_kernel(realw* potential_dot_dot_a
   // because of grid shape, irec_local can be too big
   if (irec_local < nadj_rec_local) {
 
-    int irec = pre_computed_irec[irec_local];
-
-    int ispec = ispec_selected_rec[irec]-1;
+    int ispec = ispec_selected_rec_loc[irec_local]-1;
     if (ispec_is_acoustic[ispec]) {
 
       int i = threadIdx.x;
@@ -280,9 +277,8 @@ void FC_FUNC_(add_sources_ac_sim_2_or_3_cuda,
                                                                                 mp->d_gammar_store_loc,
                                                                                 mp->d_ibool,
                                                                                 mp->d_ispec_is_acoustic,
-                                                                                mp->d_ispec_selected_rec,
+                                                                                mp->d_ispec_selected_rec_loc,
                                                                                 it_index,
-                                                                                mp->d_pre_computed_irec,
                                                                                 mp->nadj_rec_local,
                                                                                 mp->d_kappastore,
                                                                                 *NSTEP);

--- a/src/cuda/compute_add_sources_viscoelastic_cuda.cu
+++ b/src/cuda/compute_add_sources_viscoelastic_cuda.cu
@@ -184,9 +184,8 @@ __global__ void add_sources_el_SIM_TYPE_2_OR_3_kernel(realw* accel,
                                                       realw* gammar_store,
                                                       int* d_ibool,
                                                       int* ispec_is_elastic,
-                                                      int* ispec_selected_rec,
+                                                      int* ispec_selected_rec_loc,
                                                       int it,
-                                                      int* pre_computed_irec,
                                                       int nadj_rec_local,
                                                       int NSTEP) {
 
@@ -194,9 +193,7 @@ __global__ void add_sources_el_SIM_TYPE_2_OR_3_kernel(realw* accel,
 
   if (irec_local < nadj_rec_local) { // when nrec > 65535, but mod(nspec_top,2) > 0, we end up with an extra block.
 
-    int irec = pre_computed_irec[irec_local];
-
-    int ispec = ispec_selected_rec[irec]-1;
+    int ispec = ispec_selected_rec_loc[irec_local]-1;
 
     if (ispec_is_elastic[ispec]) {
       int i = threadIdx.x;
@@ -261,9 +258,8 @@ void FC_FUNC_(add_sources_el_sim_type_2_or_3,
                                                                                mp->d_gammar_store_loc,
                                                                                mp->d_ibool,
                                                                                mp->d_ispec_is_elastic,
-                                                                               mp->d_ispec_selected_rec,
+                                                                               mp->d_ispec_selected_rec_loc,
                                                                                it_index,
-                                                                               mp->d_pre_computed_irec,
                                                                                mp->nadj_rec_local,
                                                                                *NSTEP);
 

--- a/src/cuda/mesh_constants_cuda.h
+++ b/src/cuda/mesh_constants_cuda.h
@@ -415,8 +415,7 @@ typedef struct mesh_ {
   realw* d_source_time_function;
 
   // receivers
-  int* d_number_receiver_global;
-  int* d_ispec_selected_rec;
+  int* d_ispec_selected_rec_loc;
   int nrec_local;
 
   realw* h_seismograms;
@@ -428,7 +427,6 @@ typedef struct mesh_ {
   int nadj_rec_local;
   realw* d_adj_sourcearrays;
   realw* h_adj_sourcearrays_slice;
-  int* d_pre_computed_irec;
   realw* d_source_adjointe;
   realw* d_xir_store_loc;
   realw* d_gammar_store_loc;

--- a/src/cuda/write_seismograms_cuda.cu
+++ b/src/cuda/write_seismograms_cuda.cu
@@ -88,8 +88,7 @@ __global__ void compute_elastic_seismogram_kernel(int nrec_local,
                                                          realw* seismograms,
                                                          realw* cosrot,
                                                          realw* sinrot,
-                                                         int* number_receiver_global,
-                                                         int* ispec_selected_rec) {
+                                                         int* ispec_selected_rec_loc) {
 
 
   int irec_local = blockIdx.x + blockIdx.y*gridDim.x;
@@ -103,8 +102,7 @@ __global__ void compute_elastic_seismogram_kernel(int nrec_local,
 
   if (irec_local < nrec_local) {
 
-    int irec = number_receiver_global[irec_local]-1;
-    int ispec = ispec_selected_rec[irec]-1;
+    int ispec = ispec_selected_rec_loc[irec_local]-1;
 
    sh_dxd[tx] = 0;
    sh_dzd[tx] = 0;
@@ -136,8 +134,7 @@ __global__ void compute_acoustic_seismogram_kernel(int nrec_local,
                                                          int* d_ibool,
                                                          realw* hxir, realw* hgammar,
                                                          realw* seismograms,
-                                                         int* number_receiver_global,
-                                                         int* ispec_selected_rec) {
+                                                         int* ispec_selected_rec_loc) {
   int irec_local = blockIdx.x + blockIdx.y*gridDim.x;
   int tx = threadIdx.x;
   int J = (tx/NGLLX);
@@ -149,8 +146,7 @@ __global__ void compute_acoustic_seismogram_kernel(int nrec_local,
 
   if (irec_local < nrec_local) {
 
-    int irec = number_receiver_global[irec_local]-1;
-    int ispec = ispec_selected_rec[irec]-1;
+    int ispec = ispec_selected_rec[irec_local]-1;
 
    sh_dxd[tx] = 0;
 realw hlagrange;
@@ -214,8 +210,7 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                   mp->d_seismograms,
                                                                                   mp->d_cosrot,
                                                                                   mp->d_sinrot,
-                                                                                  mp->d_number_receiver_global,
-                                                                                  mp->d_ispec_selected_rec
+                                                                                  mp->d_ispec_selected_rec_loc
                                                                                   );
 
   break;
@@ -230,8 +225,7 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                   mp->d_seismograms,
                                                                                   mp->d_cosrot,
                                                                                   mp->d_sinrot,
-                                                                                  mp->d_number_receiver_global,
-                                                                                  mp->d_ispec_selected_rec
+                                                                                  mp->d_ispec_selected_rec_loc
                                                                                   );
   break;
 
@@ -245,8 +239,7 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                   mp->d_seismograms,
                                                                                   mp->d_cosrot,
                                                                                   mp->d_sinrot,
-                                                                                  mp->d_number_receiver_global,
-                                                                                  mp->d_ispec_selected_rec
+                                                                                  mp->d_ispec_selected_rec_loc
                                                                                   );
   break;
 
@@ -259,8 +252,7 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                   mp->d_ibool,
                                                                                   mp->d_xir_store_loc, mp->d_gammar_store_loc,
                                                                                   mp->d_seismograms,
-                                                                                  mp->d_number_receiver_global,
-                                                                                  mp->d_ispec_selected_rec
+                                                                                  mp->d_ispec_selected_rec_loc
                                                                                   );
   else
   compute_acoustic_seismogram_kernel<<<grid,threads,0,mp->compute_stream>>>(      mp->nrec_local,
@@ -268,8 +260,7 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                   mp->d_ibool,
                                                                                   mp->d_xir_store_loc, mp->d_gammar_store_loc,
                                                                                   mp->d_seismograms,
-                                                                                  mp->d_number_receiver_global,
-                                                                                  mp->d_ispec_selected_rec
+                                                                                  mp->d_ispec_selected_rec_loc
                                                                                   );
 
   break;

--- a/src/specfem2D/compute_add_sources_acoustic.f90
+++ b/src/specfem2D/compute_add_sources_acoustic.f90
@@ -234,46 +234,42 @@
 
   subroutine compute_add_sources_acoustic_adjoint()
 
-  use constants, only: NGLLX,NGLLZ
+  use constants, only: NGLLX,NGLLZ,CUSTOM_REAL
 
-  use specfem_par, only: myrank,potential_dot_dot_acoustic,ispec_is_acoustic,NSTEP,it, &
-                         nrec,islice_selected_rec,ispec_selected_rec,adj_sourcearrays, &
-                         ibool,kappastore
+  use specfem_par, only: potential_dot_dot_acoustic,ispec_is_acoustic,NSTEP,it, &
+                         nrecloc,ispec_selected_rec_loc,&
+                         ibool,kappastore,source_adjointe,xir_store_loc,gammar_store_loc
   implicit none
 
   !local variables
-  integer :: irec_local,irec,i,j,iglob,ispec
+  integer :: irec_local,i,j,iglob,ispec
   integer :: it_tmp
 
   ! time step index
   it_tmp = NSTEP - it + 1
 
-  irec_local = 0
-  do irec = 1,nrec
-    ! add the source (only if this proc carries the source)
-    if (myrank == islice_selected_rec(irec)) then
-      irec_local = irec_local + 1
+  do irec_local = 1,nrecloc
 
-      ! element containing adjoint source
-      ispec = ispec_selected_rec(irec)
+    ! element containing adjoint source
+    ispec = ispec_selected_rec_loc(irec_local)
 
-      if (ispec_is_acoustic(ispec)) then
-        ! add source array
-        do j = 1,NGLLZ
-          do i = 1,NGLLX
-            iglob = ibool(i,j,ispec)
+    if (ispec_is_acoustic(ispec)) then
+      ! add source array
+      do j = 1,NGLLZ
+        do i = 1,NGLLX
+          iglob = ibool(i,j,ispec)
 
-            !ZN becareful the following line is new added, thus when do comparison
-            !ZN of the new code with the old code, you will have big difference if you
-            !ZN do not tune the source
-            potential_dot_dot_acoustic(iglob) = potential_dot_dot_acoustic(iglob) + &
-                                                adj_sourcearrays(irec_local,it_tmp,1,i,j) &
-                                                / kappastore(i,j,ispec)
-          enddo
+          !ZN becareful the following line is new added, thus when do comparison
+          !ZN of the new code with the old code, you will have big difference if you
+          !ZN do not tune the source
+          potential_dot_dot_acoustic(iglob) = potential_dot_dot_acoustic(iglob) + &
+                                              real(xir_store_loc(irec_local,i)*gammar_store_loc(irec_local,j)* &
+                                              source_adjointe(irec_local,it_tmp,1),kind=CUSTOM_REAL) &
+                                              / kappastore(i,j,ispec)
         enddo
-      endif ! if element acoustic
-    endif ! if this processor core carries the adjoint source
-  enddo ! irec = 1,nrec
+      enddo
+    endif ! if element acoustic
+  enddo ! irec_local = 1,nrecloc
 
   end subroutine compute_add_sources_acoustic_adjoint
 

--- a/src/specfem2D/compute_add_sources_viscoelastic.f90
+++ b/src/specfem2D/compute_add_sources_viscoelastic.f90
@@ -333,51 +333,49 @@
 
   use constants, only: CUSTOM_REAL,NGLLX,NGLLZ
 
-  use specfem_par, only: myrank,P_SV,accel_elastic,ispec_is_elastic,NSTEP,it, &
-                         nrec,islice_selected_rec,ispec_selected_rec,adj_sourcearrays, &
-                         ibool
+  use specfem_par, only: P_SV,accel_elastic,ispec_is_elastic,NSTEP,it, &
+                         nrecloc,ispec_selected_rec_loc,ibool,&
+                         source_adjointe,xir_store_loc,gammar_store_loc
   implicit none
 
   !local variables
-  integer :: irec_local,irec,i,j,iglob,ispec
+  integer :: irec_local,i,j,iglob,ispec
   integer :: it_tmp
 
   ! time step index
   it_tmp = NSTEP - it + 1
 
-  irec_local = 0
-  do irec = 1,nrec
-    !   add the source (only if this proc carries the source)
-    if (myrank == islice_selected_rec(irec)) then
-      irec_local = irec_local + 1
+  do irec_local = 1,nrecloc
 
-      ! element containing adjoint source
-      ispec = ispec_selected_rec(irec)
+    ! element containing adjoint source
+    ispec = ispec_selected_rec_loc(irec_local)
 
-      if (ispec_is_elastic(ispec)) then
-        ! add source array
-        if (P_SV) then
-          ! P-SH waves
-          do j = 1,NGLLZ
-            do i = 1,NGLLX
-              iglob = ibool(i,j,ispec)
-              accel_elastic(1,iglob) = accel_elastic(1,iglob) + adj_sourcearrays(irec_local,it_tmp,1,i,j)
-              accel_elastic(2,iglob) = accel_elastic(2,iglob) + adj_sourcearrays(irec_local,it_tmp,2,i,j)
-            enddo
+    if (ispec_is_elastic(ispec)) then
+      ! add source array
+      if (P_SV) then
+        ! P-SH waves
+        do j = 1,NGLLZ
+          do i = 1,NGLLX
+            iglob = ibool(i,j,ispec)
+            accel_elastic(1,iglob) = accel_elastic(1,iglob) + real(xir_store_loc(irec_local,i)*gammar_store_loc(irec_local,j)* &
+                                        source_adjointe(irec_local,it_tmp,1),kind=CUSTOM_REAL)
+            accel_elastic(2,iglob) = accel_elastic(2,iglob) + real(xir_store_loc(irec_local,i)*gammar_store_loc(irec_local,j)* &
+                                        source_adjointe(irec_local,it_tmp,2),kind=CUSTOM_REAL)
           enddo
-        else
-          ! SH (membrane) wavescompute_forces_v
-          do j = 1,NGLLZ
-            do i = 1,NGLLX
-              iglob = ibool(i,j,ispec)
-              accel_elastic(1,iglob) = accel_elastic(1,iglob) + adj_sourcearrays(irec_local,it_tmp,1,i,j)
-            enddo
+        enddo
+      else
+        ! SH (membrane) wavescompute_forces_v
+        do j = 1,NGLLZ
+          do i = 1,NGLLX
+            iglob = ibool(i,j,ispec)
+            accel_elastic(1,iglob) = accel_elastic(1,iglob) +  real(xir_store_loc(irec_local,i)*gammar_store_loc(irec_local,j)* &
+                                        source_adjointe(irec_local,it_tmp,1),kind=CUSTOM_REAL)
           enddo
-        endif
-      endif ! if element is elastic
-    endif ! if this processor core carries the adjoint source and the source element is elastic
+        enddo
+      endif
+    endif ! if element is elastic
 
-  enddo ! irec = 1,nrec
+  enddo ! irec_local = 1,nrecloc
 
   end subroutine compute_add_sources_viscoelastic_adjoint
 

--- a/src/specfem2D/compute_interpolated_dva.f90
+++ b/src/specfem2D/compute_interpolated_dva.f90
@@ -31,15 +31,15 @@
 !
 !=====================================================================
 
-  subroutine compute_interpolated_dva(irec,ispec,vector_field_element,pressure_element,curl_element, &
+  subroutine compute_interpolated_dva(irecloc,ispec,vector_field_element,pressure_element,curl_element, &
                                       vx,vz,vcurl)
 
   use constants, only: CUSTOM_REAL,NDIM,NGLLX,NGLLZ
-  use specfem_par, only: hxir_store,hgammar_store,ibool,seismotype
+  use specfem_par, only: xir_store_loc,gammar_store_loc,ibool,seismotype
 
   implicit none
 
-  integer,intent(in) :: irec,ispec
+  integer,intent(in) :: irecloc,ispec
   real(kind=CUSTOM_REAL), dimension(NDIM,NGLLX,NGLLZ),intent(in) :: vector_field_element
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLZ),intent(in) :: pressure_element
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLZ),intent(in) :: curl_element
@@ -58,7 +58,7 @@
   do j = 1,NGLLZ
     do i = 1,NGLLX
       iglob = ibool(i,j,ispec)
-      hlagrange = hxir_store(irec,i)*hgammar_store(irec,j)
+      hlagrange = xir_store_loc(irecloc,i)*gammar_store_loc(irecloc,j)
 
       ! displacement/velocity/acceleration/pressure value (depending on seismotype)
       select case (seismotype)
@@ -95,5 +95,3 @@
   enddo
 
   end subroutine compute_interpolated_dva
-
-

--- a/src/specfem2D/prepare_gpu.f90
+++ b/src/specfem2D/prepare_gpu.f90
@@ -78,8 +78,7 @@
 ! sourcearray_loc(i_src,dim,i,j)         : tableau de ponderation de l'intensite de la source pour chaque point GLL (i,j)
 !                                          de l'element spectral qui contient la source locale i_src
 ! ispec_selected_source(i)               : numero d'element spectral contenant la source locale i
-! recloc(i)                              : convertisseur numero rec local i => numero rec global
-! ispec_selected_rec(i)                  : numero d'element spectral du receveur i
+! ispec_selected_rec_loc(i)              : numero d'element spectral du receveur local i
 ! nrecloc                                : nombre de receveurs locaux
 ! nspec_acoustic                         : nombre local d'elements spectraux acoustiques
 
@@ -113,7 +112,7 @@
                                 nsources_local, &
                                 sourcearray_loc,source_time_function_loc, &
                                 NSTEP,ispec_selected_source_loc, &
-                                recloc, ispec_selected_rec, &
+                                ispec_selected_rec_loc, &
                                 nrec, nrecloc, &
                                 cosrot_irecf,sinrot_irecf, &
                                 SIMULATION_TYPE, &

--- a/src/specfem2D/setup_sources_receivers.F90
+++ b/src/specfem2D/setup_sources_receivers.F90
@@ -187,7 +187,7 @@
 #endif
 
   use specfem_par, only: coord,ibool,nglob,nspec, &
-                         ispec_selected_rec, &
+                         ispec_selected_rec,ispec_selected_rec_loc, &
                          NPROC,myrank,coorg,knods,ngnod, &
                          xigll,zigll,npgeo, &
                          nrec,nrecloc,recloc,islice_selected_rec,st_xval,st_zval, &
@@ -200,10 +200,7 @@
   ! Local variables
   integer :: nrec_tot_found
   integer :: ier
-
-#ifndef USE_MPI
-  integer :: irec
-#endif
+  integer :: irec,irec_local
 
   character(len=MAX_STRING_LEN) :: dummystring
 
@@ -299,6 +296,17 @@
   ! checks if acoustic receiver is exactly on the free surface because pressure is zero there
   call setup_receivers_check_acoustic()
 
+  ! create a local array for receivers
+  allocate(ispec_selected_rec_loc(nrecloc))
+  irec_local = 0
+  do irec = 1, nrec
+    if (myrank == islice_selected_rec(irec)) then
+      if (irec_local > nrecloc) stop 'Error with the number of local sources'
+      irec_local = irec_local + 1
+      ispec_selected_rec_loc(irec_local)  = ispec_selected_rec(irec)
+    endif
+  enddo
+
   end subroutine setup_receivers
 
 
@@ -379,18 +387,14 @@
   use constants, only: CUSTOM_REAL,NGLLX,NGLLZ,NDIM,MAX_STRING_LEN,IMAIN
 
   use specfem_par, only: nadj_rec_local,nrec,nrecloc,NSTEP,NPROC,SIMULATION_TYPE,SU_FORMAT, &
-                        adj_sourcearrays, &
                         myrank,islice_selected_rec,seismotype, &
                         xi_receiver,gamma_receiver, &
-                        network_name,station_name,GPU_MODE
-
-  use specfem_par_gpu, only: source_adjointe
+                        network_name,station_name,source_adjointe
 
   implicit none
 
   ! local parameters
   integer :: irec,irec_local
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: adj_sourcearray
   character(len=MAX_STRING_LEN) :: adj_source_file
 
   ! number of adjoint receivers in this slice
@@ -409,10 +413,7 @@
       call flush_IMAIN()
     endif
 
-    ! for GPU-version
-    if (GPU_MODE) then
-      allocate(source_adjointe(nrecloc,NSTEP,2))
-    endif
+    allocate(source_adjointe(nrecloc,NSTEP,2))
 
     ! counts number of adjoint sources in this slice
     do irec = 1,nrec
@@ -427,14 +428,6 @@
       endif
     enddo
 
-    ! array for all adjoint sources
-    if (nadj_rec_local > 0) then
-      allocate(adj_sourcearrays(nadj_rec_local,NSTEP,NDIM,NGLLX,NGLLZ))
-    else
-      allocate(adj_sourcearrays(1,1,1,1,1))
-    endif
-    adj_sourcearrays(:,:,:,:,:) = 0._CUSTOM_REAL
-
     ! reads in adjoint source files
     if (.not. SU_FORMAT) then
       ! user output
@@ -443,9 +436,6 @@
         call flush_IMAIN()
       endif
 
-      ! temporary array
-      allocate(adj_sourcearray(NSTEP,NDIM,NGLLX,NGLLZ))
-
       ! reads in ascii adjoint source files **.adj
       irec_local = 0
       do irec = 1, nrec
@@ -453,16 +443,11 @@
         if (myrank == islice_selected_rec(irec)) then
           irec_local = irec_local + 1
           adj_source_file = trim(network_name(irec))//'.'//trim(station_name(irec))
-
-          call compute_arrays_adj_source(xi_receiver(irec),gamma_receiver(irec),irec_local,adj_source_file,adj_sourcearray)
-
-          adj_sourcearrays(irec_local,:,:,:,:) = adj_sourcearray(:,:,:,:)
+          call read_adj_source(xi_receiver(irec),gamma_receiver(irec),irec_local,adj_source_file)
         endif
       enddo
       ! checks
       if (irec_local /= nadj_rec_local) stop 'Error invalid number of local adjoint sources found'
-      ! frees temporary array
-      deallocate(adj_sourcearray)
     else
       ! user output
       if (myrank == 0) then
@@ -471,7 +456,7 @@
       endif
 
       ! (SU_FORMAT)
-      call compute_arrays_adj_source_SU(seismotype)
+      call read_adj_source_SU(seismotype)
     endif
 
     ! user output
@@ -479,9 +464,6 @@
       write(IMAIN,*) '  number of adjoint sources = ',nrec
       call flush_IMAIN()
     endif
-  else
-    ! dummy allocation
-    allocate(adj_sourcearrays(1,1,1,1,1))
   endif ! SIMULATION_TYPE == 3
 
   ! synchronizes all processes
@@ -868,10 +850,8 @@
   use specfem_par, only: myrank,nrec,nrecloc, &
     ispec_selected_rec,islice_selected_rec, &
     xigll,zigll, &
-    hxir_store,hgammar_store,xi_receiver,gamma_receiver,hxir,hpxir,hgammar,hpgammar, &
-    AXISYM,is_on_the_axis,xiglj
-
-  use specfem_par_gpu, only: xir_store_loc,gammar_store_loc
+    xi_receiver,gamma_receiver,hxir,hpxir,hgammar,hpgammar, &
+    AXISYM,is_on_the_axis,xiglj,xir_store_loc,gammar_store_loc
 
   implicit none
 
@@ -879,10 +859,6 @@
   integer :: irec,irec_local,ier
 
   ! allocate Lagrange interpolators for receivers
-  allocate(hxir_store(nrec,NGLLX), &
-           hgammar_store(nrec,NGLLZ),stat=ier)
-  if (ier /= 0) stop 'Error allocating receiver h**_store arrays'
-
   allocate(xir_store_loc(nrecloc,NGLLX), &
            gammar_store_loc(nrecloc,NGLLZ),stat=ier)
   if (ier /= 0) stop 'Error allocating local receiver h**_store arrays'
@@ -911,10 +887,6 @@
       !  double precision, external :: hglj,hgll
     endif
     call lagrange_any(gamma_receiver(irec),NGLLZ,zigll,hgammar,hpgammar)
-
-    ! stores Lagrangians for receiver
-    hxir_store(irec,:) = hxir(:)
-    hgammar_store(irec,:) = hgammar(:)
 
     ! local receivers in this slice
     if (myrank == islice_selected_rec(irec)) then

--- a/src/specfem2D/specfem2D_par.f90
+++ b/src/specfem2D/specfem2D_par.f90
@@ -209,7 +209,7 @@ module specfem_par
   double precision :: xirec,gammarec
   integer, dimension(:), allocatable :: recloc
   integer, dimension(:), allocatable :: islice_selected_rec
-  integer, dimension(:), allocatable :: ispec_selected_rec
+  integer, dimension(:), allocatable :: ispec_selected_rec,ispec_selected_rec_loc
   double precision, dimension(:), allocatable :: xi_receiver,gamma_receiver,st_xval,st_zval
 
   ! tangential detection for source or receivers
@@ -595,6 +595,8 @@ module specfem_par
   ! adjoint sources
   integer :: nadj_rec_local
   real(kind=CUSTOM_REAL), dimension(:,:,:,:,:), allocatable :: adj_sourcearrays
+  real(kind=CUSTOM_REAL),  dimension(:,:,:), allocatable :: source_adjointe
+  real(kind=CUSTOM_REAL),  dimension(:,:), allocatable :: xir_store_loc, gammar_store_loc
 
   ! absorbing boundary
   logical :: anyabs
@@ -787,11 +789,6 @@ module specfem_par_gpu
   integer, dimension(:), allocatable :: ispec_selected_source_loc
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: sourcearray_loc
   real(kind=CUSTOM_REAL), dimension(:,:), allocatable ::  source_time_function_loc
-
-  real(kind=CUSTOM_REAL),  dimension(:,:,:), allocatable :: source_adjointe
-
-  ! receivers
-  real(kind=CUSTOM_REAL),  dimension(:,:), allocatable :: xir_store_loc, gammar_store_loc
 
   ! coupling
   integer, dimension(:), allocatable :: coupling_ac_el_ispec

--- a/src/specfem2D/write_seismograms.F90
+++ b/src/specfem2D/write_seismograms.F90
@@ -42,7 +42,7 @@
   implicit none
 
   ! local parameters
-  integer :: i, j, iglob, irecloc, irec, ispec
+  integer :: i, j, iglob, irecloc, ispec
   double precision :: valux,valuz,valcurl
 
   ! vector field in an element
@@ -70,8 +70,7 @@
         ! on CPU
         do irecloc = 1,nrecloc
 
-          irec = recloc(irecloc)
-          ispec = ispec_selected_rec(irec)
+          ispec = ispec_selected_rec_loc(irecloc)
 
           ! initializes local element arrays
           vector_field_element(:,:,:) = 0._CUSTOM_REAL
@@ -131,7 +130,7 @@
           end select
 
           ! perform the general interpolation using Lagrange polynomials
-          call compute_interpolated_dva(irec,ispec,vector_field_element,pressure_element,curl_element, &
+          call compute_interpolated_dva(irecloc,ispec,vector_field_element,pressure_element,curl_element, &
                                         valux,valuz,valcurl)
 
           ! rotate seismogram components if needed, except if recording pressure, which is a scalar


### PR DESCRIPTION
This change can be useful to save memory for adjoint simulations involving a large number of time steps and a large number of receivers within a MPI partition.