### PR TITLE
Update interpolate.f90

### DIFF
--- a/EXAMPLES/Industrial_Format_SEP/interpolate.f90
+++ b/EXAMPLES/Industrial_Format_SEP/interpolate.f90
@@ -234,7 +234,7 @@
   ! interpolating model values onto all GLL points
   ! (uses slowness values for interpolation)
   vp_SEP(:,:) = 1.0/vp_SEP(:,:)
-  vs_SEP(:,:) = 1.0/vs_SEP(:,:)
+  !vs_SEP(:,:) = 1.0/vs_SEP(:,:)
   rho_SEP(:,:) = 1.0/rho_SEP(:,:)
 
   call interpolate_gll(vp_SEP,vs_SEP,rho_SEP,NX,NY,NZ,DX,DY,DZ,OX,OY,OZ,INTERPOLATE_FROM_CLOSEST_POINT,nproc)
@@ -475,7 +475,7 @@
       ! (converting from slowness to wave speed values again)
       if (ier == 0) then
         do i = 1,NGLLX*NGLLZ
-          write(16,'(I10,5e15.5e4)') iglob(i),x(i),z(i), 1.d0/rho_new(i), 1.d0/vp_new(i), 1.d0/vs_new(i)
+          write(16,'(I10,5e15.5e4)') iglob(i),x(i),z(i), 1.d0/rho_new(i), 1.d0/vp_new(i), vs_new(i)
         enddo
       endif
     enddo


### PR DESCRIPTION
Please go to line 458 - line 460
          ! interpolates vs
          ! note: not sure why inverted vs values are used again here...
          !       vp above uses slowness values for interpolations

The inverse of vs is reserved for the solid-liquid coupling case, in which Vs = 0 such that we cannot get its inverse globally but coud locally. 
So we could cancel line 237 and modify line 478 to
          write(16,'(I10,5e15.5e4)') iglob(i),x(i),z(i), 1.d0/rho_new(i), 1.d0/vp_new(i), vs_new(i)

In this way, this module should work.