### PR TITLE
Enhance I/O of binary seismograms

### DIFF
--- a/src/cuda/prepare_mesh_constants_cuda.cu
+++ b/src/cuda/prepare_mesh_constants_cuda.cu
@@ -335,9 +335,9 @@ void FC_FUNC_(prepare_constants_device,
   mp->nrec_local = *nrec_local; // number of receiver located in this partition
   // note that: size of size(ispec_selected_rec_loc) = nrec_local
   if (mp->nrec_local > 0) {
-    print_CUDA_error_if_any(cudaMalloc((void**)&mp->d_seismograms,sizeof(realw)*(mp->nrec_local)*2),1303);
+    print_CUDA_error_if_any(cudaMalloc((void**)&mp->d_seismograms,2*(*NSTEP)*sizeof(realw)*(mp->nrec_local)*2),1303);
     // pinned memory
-    print_CUDA_error_if_any(cudaMallocHost((void**)&(mp->h_seismograms),sizeof(realw)*(mp->nrec_local)*2),8004);
+    print_CUDA_error_if_any(cudaMallocHost((void**)&(mp->h_seismograms),2*(*NSTEP)*sizeof(realw)*(mp->nrec_local)*2),8004);
     // host memory
     //mp->h_seismograms = (float*)malloc((mp->nrec_local)*2*sizeof(float));
     //if (mp->h_seismograms == NULL) exit_on_error("h_seismograms not allocated \n");

--- a/src/specfem2D/write_seismograms.F90
+++ b/src/specfem2D/write_seismograms.F90
@@ -440,20 +440,20 @@
             do isample = 1, NSTEP
               single_precision_seismo(isample) = sngl(buffer_binary(isample,irec,1)) 
             enddo  
-            write(12,rec=(irec-1)*NSTEP) single_precision_seismo
+            write(12,rec=(irec-1)*NSTEP+1) single_precision_seismo
           endif
           if (save_binary_seismograms_double) &
-            write(13,rec=(irec-1)*NSTEP) buffer_binary(:,irec,1)
+            write(13,rec=(irec-1)*NSTEP+1) buffer_binary(:,irec,1)
 
           if (seismotype /= 4 .and. seismotype /= 6 .and. P_SV) then
             if (save_binary_seismograms_single) then
               do isample = 1, NSTEP
                 single_precision_seismo(isample) = sngl(buffer_binary(isample,irec,2))
               enddo 
-              write(14,rec=(irec-1)*NSTEP) single_precision_seismo
+              write(14,rec=(irec-1)*NSTEP+1) single_precision_seismo
             endif
             if (save_binary_seismograms_double) &
-              write(15,rec=(irec-1)*NSTEP) buffer_binary(:,irec,2)
+              write(15,rec=(irec-1)*NSTEP+1) buffer_binary(:,irec,2)
           endif
 
           if (seismotype == 5) then
@@ -461,10 +461,10 @@
               do isample = 1, NSTEP
                 single_precision_seismo(isample) = sngl(buffer_binary(isample,irec,3))
               enddo
-              write(16,rec=(irec-1)*NSTEP+isample) single_precision_seismo
+              write(16,rec=(irec-1)*NSTEP+1) single_precision_seismo
             endif
             if (save_binary_seismograms_double) &
-              write(17,rec=(irec-1)*NSTEP+isample) buffer_binary(:,irec,3)
+              write(17,rec=(irec-1)*NSTEP+1) buffer_binary(:,irec,3)
           endif
 
         endif


### PR DESCRIPTION
- One disk access per seismogram to write it on file, instead of more than NSTEP disk accesses previously, for binary (.bin and .su).
- One communication CPU <==> GPU per simulation regarding seismograms, instead of NSTEP previously.