### PR TITLE
better memory gestion for the acoustic case in UNDO_ATTENUATION

### DIFF
--- a/src/specfem2D/compute_kernels.f90
+++ b/src/specfem2D/compute_kernels.f90
@@ -312,7 +312,7 @@
                          poroelastcoef,density,kmato,assign_external_model,rhoext,vpext,deltat, &
                          hprime_xx,hprime_zz,xix,xiz,gammax,gammaz, &
                          potential_acoustic,b_potential_acoustic,potential_dot_dot_acoustic, &
-                         accel_ac,b_accel_ac,b_displ_ac, &
+                         accel_ac,b_displ_ac, &
                          rho_ac_kl,kappa_ac_kl,rhop_ac_kl,alpha_ac_kl,GPU_MODE
 
   use specfem_par_gpu, only: Mesh_pointer,deltatf


### PR DESCRIPTION
-The kappa_kernel expression is changed from (b_p_dot_dot * p)  to  (p_dot_dot * b_p), which are equivalent, in order to not need to keep b_p_dot_dot in the buffer.

-Also, elastic kernel computation are optimized. Beware, the current expression are incorrect, the product of forward and adjoint strain are kept in memory with global numbering, but it has to be local (ngll2*NSPEC) since strain is discontinuous.