### PR TITLE
fixed the bug of infinite loop in exit_MPI

### DIFF
--- a/src/shared/exit_mpi.F90
+++ b/src/shared/exit_mpi.F90
@@ -66,7 +66,7 @@
 ! close output file
   if (myrank == 0 .and. IMAIN /= ISTANDARD_OUTPUT) close(IMAIN)
 
-  call abort_mpi()
+  if (error_msg /= "Error, program ended in exit_MPI") call abort_mpi()
 
   end subroutine exit_MPI
 


### PR DESCRIPTION
Currently exit_MPI() will call abort_mpi(), which calls exit_MPI() again.