### PR TITLE
Inconsistent source time function for Newmark format during forward simulation, i.e. SIMULATION_TYPE == 1.

### DIFF
--- a/src/specfem2D/compute_add_sources_poro.f90
+++ b/src/specfem2D/compute_add_sources_poro.f90
@@ -40,7 +40,8 @@
   use specfem_par, only: myrank,ispec_is_poroelastic,nglob_poroelastic, &
                          NSOURCES,source_time_function,sourcearrays, &
                          islice_selected_source,ispec_selected_source, &
-                         ibool,porosity,tortuosity,density,kmato,time_stepping_scheme
+                         ibool,porosity,tortuosity,density,kmato,&
+                         SIMULATION_TYPE,time_stepping_scheme
   implicit none
 
   real(kind=CUSTOM_REAL), dimension(NDIM,nglob_poroelastic) :: accels_poroelastic,accelw_poroelastic

--- a/src/specfem2D/compute_add_sources_viscoelastic.f90
+++ b/src/specfem2D/compute_add_sources_viscoelastic.f90
@@ -40,7 +40,7 @@
   use specfem_par, only: myrank,P_SV,ispec_is_elastic,nglob_elastic, &
                          NSOURCES,source_time_function, &
                          islice_selected_source,ispec_selected_source,sourcearrays, &
-                         ibool
+                         ibool,SIMULATITION_TYPE,time_stepping_scheme
   implicit none
 
   real(kind=CUSTOM_REAL), dimension(NDIM,nglob_elastic) :: accel_elastic

--- a/src/specfem2D/compute_add_sources_viscoelastic.f90
+++ b/src/specfem2D/compute_add_sources_viscoelastic.f90
@@ -63,7 +63,16 @@
       if (ispec_is_elastic(ispec)) then
 
         ! source time function
-        stf_used = source_time_function(i_source,it,i_stage)
+        if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+           ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+           if (it < NSTEP) then
+              stf_used = source_time_function(i_source,it+1,i_stage)
+           else
+              stf_used = 0.d0
+           end if
+        else
+           stf_used = source_time_function(i_source,it,i_stage)
+        end if
 
         ! adds source term
         ! note: we use sourcearrays for both collocated forces and moment tensors

--- a/src/specfem2D/invert_mass_matrix.F90
+++ b/src/specfem2D/invert_mass_matrix.F90
@@ -111,7 +111,7 @@
         ! if external density model (elastic or acoustic)
         if (assign_external_model) then
           rhol = rhoext(i,j,ispec)
-          mul = rhol * vsext(i,j,ispec)
+          mul = rhol * vsext(i,j,ispec)**2
           if (AXISYM) then ! CHECK kappa mm
             kappal_relaxed = rhol * vpext(i,j,ispec)**2 - TWO_THIRDS * mul ! CHECK Kappa
           else


### PR DESCRIPTION
For the format format:

In prediction phase:
displ(it+1) = displ(it) + deltatveloc(it) + deltatquareover2accel(it)
veloc(it+1/2) = veloc(it) + deltatover2*accel(it)
In correction phase:
accel(it+1) = F(it+1) - Kdispl(it+1)
veloc(it+1) = veloc(it+1/2) + deltatover2accel(it+1)
In forward simulation, all added source time functions should be at t+deltat time instant for the Newmark format because they are added to a(it+1). Now, the implementions of compute_add_sources for the Newmark format may be not correct.

Because displ(it+1) = displ(it) + deltatdispl(it) + deltatquareover2accel(it) = displ(it) + deltat*(veloc(it) + deltatover2accel(it)) = displ(it) + deltatveloc(it+1/2), we can optimize the above codes as follows:

In prediction phase:
veloc(it+1/2) = veloc(it) + deltatover2accel(it)
displ(it+1) = displ(it) + deltatveloc(it+1/2)
In correction phase:
accel(it+1) = F(it+1) - Kdispl(it+1)
veloc(it+1) = veloc(it+1/2) + deltatover2accel(it+1)
In implementation, we did not need to define new array of veloc(it+1/2).