### PR TITLE
Fixed acoustic free surface computation within the mesher

### DIFF
--- a/src/meshfem2D/determine_acoustic_surface.f90
+++ b/src/meshfem2D/determine_acoustic_surface.f90
@@ -33,7 +33,7 @@
 
   subroutine determine_acoustic_surface()
 
-  use constants, only: ANISOTROPIC_MATERIAL,TINYVAL,IMAIN,myrank
+  use constants, only: ANISOTROPIC_MATERIAL,TINYVAL,IMAIN,myrank,POROELASTIC_MATERIAL,ELECTROMAGNETIC_MATERIAL
 
   use part_unstruct_par, only: nelem_acoustic_surface,acoustic_surface, &
     nxread,nzread,elmnts
@@ -61,7 +61,8 @@
     j = nzread
     do i = 1,nxread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
        endif
     enddo
@@ -70,7 +71,8 @@
     j = 1
     do i = 1,nxread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
        endif
     enddo
@@ -80,7 +82,8 @@
     i = 1
     do j = 1,nzread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
        endif
     enddo
@@ -89,7 +92,8 @@
     i = nxread
     do j = 1,nzread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
        endif
     enddo
@@ -111,7 +115,8 @@
     j = nzread
     do i = 1,nxread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
           acoustic_surface(1,nelem_acoustic_surface) = (j-1)*nxread + (i-1)
           acoustic_surface(2,nelem_acoustic_surface) = 2
@@ -124,7 +129,8 @@
     j = 1
     do i = 1,nxread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
           acoustic_surface(1,nelem_acoustic_surface) = (j-1)*nxread + (i-1)
           acoustic_surface(2,nelem_acoustic_surface) = 2
@@ -138,7 +144,8 @@
     i = 1
     do j = 1,nzread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
           acoustic_surface(1,nelem_acoustic_surface) = (j-1)*nxread + (i-1)
           acoustic_surface(2,nelem_acoustic_surface) = 2
@@ -151,7 +158,8 @@
     i = nxread
     do j = 1,nzread
        imaterial_number = num_material((j-1)*nxread+i)
-       if (icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL .and. phi_read(imaterial_number) >= 1.d0) then
+       if ((icodemat(imaterial_number) /= ANISOTROPIC_MATERIAL) .and. (phi_read(imaterial_number) >= 1.d0) .and. &
+       (icodemat(imaterial_number) /= ELECTROMAGNETIC_MATERIAL) .and. (icodemat(imaterial_number) /= POROELASTIC_MATERIAL)) then
           nelem_acoustic_surface = nelem_acoustic_surface + 1
           acoustic_surface(1,nelem_acoustic_surface) = (j-1)*nxread + (i-1)
           acoustic_surface(2,nelem_acoustic_surface) = 2


### PR DESCRIPTION
Currently, the mesher assigns acoustic free surface to poroelastic and electromagnetic elements. This is likely inconsequential within the solver since `potential` will be set to 0 for `iglobs` that are not within the acoustic domain - which would have been zero nonetheless. However, it does show up in mesher output in a predictable manner, see below: 

The following is mesher output when only EM elements are within the domain. 
```
number of acoustic elements with free surface =            240
```