### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/external_libs/libjpeg/jdpostct.c
+++ b/external_libs/libjpeg/jdpostct.c
@@ -132,6 +132,11 @@ post_process_1pass (j_decompress_ptr cinfo,
   my_post_ptr post = (my_post_ptr) cinfo->post;
   JDIMENSION num_rows, max_rows;
 
+  /* read_and_discard_scanlines may call it with rows "available", but no buffer */
+  if (output_buf == NULL) {
+    return;
+  }
+
   /* Fill the buffer, but not more than what we can dump out in one go. */
   /* Note we rely on the upsampler to detect bottom of image. */
   max_rows = out_rows_avail - *out_row_ctr;

--- a/external_libs/libjpeg/jquant1.c
+++ b/external_libs/libjpeg/jquant1.c
@@ -528,6 +528,10 @@ quantize_ord_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
 
+  if (output_buf == NULL && num_rows) {
+    ERREXIT(cinfo, JERR_BAD_PARAM);
+  }
+
   for (row = 0; row < num_rows; row++) {
     /* Initialize output values to 0 so can process components separately */
     jzero_far((void FAR *) output_buf[row],


### PR DESCRIPTION
This PR fixes a potential security vulnerability in function `quantize_ord_dither` and  `post_process_1pass` that was cloned from https://https://github.com/libjpeg-turbo/libjpeg-turbo but did not receive the security patch.

### Details:
Affected Function: 
- `quantize_ord_dither` in `libjpeg-turbo-2.0.2/jquant1.c`
- `post_process_1pass` in `libjpeg-turbo-2.0.2/jdpostct.c`
Original Fix: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/1ecd9a5729d78518397889a630e3534bd9d963a8


### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- CVE-2017-15232: https://nvd.nist.gov/vuln/detail/CVE-2017-15232
- https://github.com/libjpeg-turbo/libjpeg-turbo/pull/182/commits/1ecd9a5729d78518397889a630e3534bd9d963a8

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
